### PR TITLE
Installation Documents Overhaul

### DIFF
--- a/documentation/docs/dependencies/grafana.md
+++ b/documentation/docs/dependencies/grafana.md
@@ -10,25 +10,6 @@ Configuration is documented in [another page](../install/grafana).
 Grafana 7.4.0+ is recommended. Grafana 7.x or newer is required.
 :::
 
-## Plugins
-
-This application uses a few Grafana plugins. Install them. Grafana must be installed first, see below.
-
-- Clock
-- Discrete (InfluxDB only)
-- PieChart
-
-```shell
-grafana-cli plugins install grafana-clock-panel
-grafana-cli plugins install natel-discrete-panel
-grafana-cli plugins install grafana-piechart-panel
-```
-
-If you're running Grafana in Docker, pass this environment variable/value to Grafana to install the plugins:
-```shell
-GF_INSTALL_PLUGINS=grafana-clock-panel,natel-discrete-panel,grafana-piechart-panel
-```
-
 ## Installing
 
 :::note
@@ -36,6 +17,10 @@ You can find official instructions in the [Grafana Docs](https://grafana.com/doc
 :::
 
 This will set it up on localhost:3000 with admin/admin login.
+
+### Windows
+
+[Install instructions](https://grafana.com/docs/grafana/latest/installation/windows/) for Windows
 
 ### Linux
 
@@ -83,6 +68,26 @@ grafana/grafana
 ```
 
 Replace `YOURLOCALPATH` with a location for the data Grafana needs to write to disk.
+
+
+## Plugins
+
+This application uses a few Grafana plugins. Install them. Grafana must be installed first, see below.
+
+- Clock
+- Discrete (InfluxDB only)
+- PieChart
+
+```shell
+grafana-cli plugins install grafana-clock-panel
+grafana-cli plugins install natel-discrete-panel
+grafana-cli plugins install grafana-piechart-panel
+```
+
+If you're running Grafana in Docker, pass this environment variable/value to Grafana to install the plugins:
+```shell
+GF_INSTALL_PLUGINS=grafana-clock-panel,natel-discrete-panel,grafana-piechart-panel
+```
 
 ## Configuring
 

--- a/documentation/docs/dependencies/grafana.md
+++ b/documentation/docs/dependencies/grafana.md
@@ -93,4 +93,4 @@ GF_INSTALL_PLUGINS=grafana-clock-panel,natel-discrete-panel,grafana-piechart-pan
 ## Configuring
 
 To configure Grafana, you need to add a data source and import the dashboards.
-Learn how to do that in [Grafana Setup](../install/grafana.md).
+Learn how to do that in [Grafana Setup](../install/grafana).

--- a/documentation/docs/dependencies/grafana.md
+++ b/documentation/docs/dependencies/grafana.md
@@ -20,7 +20,8 @@ This will set it up on localhost:3000 with admin/admin login.
 
 ### Windows
 
-[Install instructions](https://grafana.com/docs/grafana/latest/installation/windows/) for Windows
+- [Install Grafana](https://grafana.com/docs/grafana/latest/installation/windows/)
+- [Install Plugins](grafana.md#plugins)
 
 ### Linux
 

--- a/documentation/docs/dependencies/grafana.md
+++ b/documentation/docs/dependencies/grafana.md
@@ -93,4 +93,4 @@ GF_INSTALL_PLUGINS=grafana-clock-panel,natel-discrete-panel,grafana-piechart-pan
 ## Configuring
 
 To configure Grafana, you need to add a data source and import the dashboards.
-Learn how to do that in [Grafana Setup](../install/grafana).
+Learn how to do that in [Grafana Setup](../install/grafana.md).

--- a/documentation/docs/dependencies/grafana.md
+++ b/documentation/docs/dependencies/grafana.md
@@ -79,6 +79,7 @@ This application uses a few Grafana plugins. Install them. Grafana must be insta
 - Discrete (InfluxDB only)
 - PieChart
 
+Using the Grafana CLI tool `grafana-cli.exe` installed in the Grafana directory:
 ```shell
 grafana-cli plugins install grafana-clock-panel
 grafana-cli plugins install natel-discrete-panel

--- a/documentation/docs/dependencies/grafana.md
+++ b/documentation/docs/dependencies/grafana.md
@@ -79,7 +79,7 @@ This application uses a few Grafana plugins. Install them. Grafana must be insta
 - Discrete (InfluxDB only)
 - PieChart
 
-Using the Grafana CLI tool `grafana-cli` installed in the Grafana directory:
+Using the Grafana CLI tool `grafana-cli` in the Grafana directory:
 ```shell
 grafana-cli plugins install grafana-clock-panel
 grafana-cli plugins install natel-discrete-panel

--- a/documentation/docs/dependencies/grafana.md
+++ b/documentation/docs/dependencies/grafana.md
@@ -79,7 +79,7 @@ This application uses a few Grafana plugins. Install them. Grafana must be insta
 - Discrete (InfluxDB only)
 - PieChart
 
-Using the Grafana CLI tool `grafana-cli.exe` installed in the Grafana directory:
+Using the Grafana CLI tool `grafana-cli` installed in the Grafana directory:
 ```shell
 grafana-cli plugins install grafana-clock-panel
 grafana-cli plugins install natel-discrete-panel

--- a/documentation/docs/dependencies/influxdb.md
+++ b/documentation/docs/dependencies/influxdb.md
@@ -23,7 +23,7 @@ Using Power Shell (Run as Administrator)
 wget https://dl.influxdata.com/influxdb/releases/influxdb-1.8.10_windows_amd64.zip -UseBasicParsing -OutFile influxdb-1.8.10_windows_amd64.zip
 Expand-Archive .\influxdb-1.8.10_windows_amd64.zip -DestinationPath 'C:\Program Files\InfluxData\influxdb\'
 ```
-Windows InfluxDB 1.x directions came [from here:](https://portal.influxdata.com/downloads/)
+Windows InfluxDB 1.x directions came [from here](https://portal.influxdata.com/downloads/)
 
 ### CentOS 7
 

--- a/documentation/docs/dependencies/influxdb.md
+++ b/documentation/docs/dependencies/influxdb.md
@@ -25,6 +25,12 @@ Expand-Archive .\influxdb-1.8.10_windows_amd64.zip -DestinationPath 'C:\Program 
 ```
 Windows InfluxDB 1.x directions came [from here](https://portal.influxdata.com/downloads/)
 
+Start & configure:
+- run `influxd.exe`
+- [configure](influxdb.md#post-setup)
+(Default install path: 'C:\Program Files\InfluxData\influxdb\')
+
+
 ### CentOS 7
 
 Provided by community: https://github.com/unifi-poller/unifi-poller/issues/30

--- a/documentation/docs/dependencies/influxdb.md
+++ b/documentation/docs/dependencies/influxdb.md
@@ -27,7 +27,7 @@ Windows InfluxDB 1.x directions came [from here](https://portal.influxdata.com/d
 
 **Start & configure:**
 - Run `influxd.exe`
-- [configure](influxdb.md#post-setup)
+- [Post setup](influxdb.md#post-setup) configuration
 
 (Default install path: 'C:\Program Files\InfluxData\influxdb\')
 

--- a/documentation/docs/dependencies/influxdb.md
+++ b/documentation/docs/dependencies/influxdb.md
@@ -25,9 +25,10 @@ Expand-Archive .\influxdb-1.8.10_windows_amd64.zip -DestinationPath 'C:\Program 
 ```
 Windows InfluxDB 1.x directions came [from here](https://portal.influxdata.com/downloads/)
 
-Start & configure:
-- run `influxd.exe`
+**Start & configure:**
+- Run `influxd.exe`
 - [configure](influxdb.md#post-setup)
+
 (Default install path: 'C:\Program Files\InfluxData\influxdb\')
 
 

--- a/documentation/docs/dependencies/influxdb.md
+++ b/documentation/docs/dependencies/influxdb.md
@@ -16,6 +16,16 @@ There are no pre-built graphs to display the data it collects.
 
 ## Installation
 
+### Windows
+
+Using Power Shell (Run as Administrator)
+```shell
+wget https://dl.influxdata.com/influxdb/releases/influxdb-1.8.10_windows_amd64.zip -UseBasicParsing -OutFile influxdb-1.8.10_windows_amd64.zip
+Expand-Archive .\influxdb-1.8.10_windows_amd64.zip -DestinationPath 'C:\Program Files\InfluxData\influxdb\'
+```
+-or-
+InfluxDB 1.x directions came [from here:](https://portal.influxdata.com/downloads/)
+
 ### CentOS 7
 
 Provided by community: https://github.com/unifi-poller/unifi-poller/issues/30

--- a/documentation/docs/dependencies/influxdb.md
+++ b/documentation/docs/dependencies/influxdb.md
@@ -29,7 +29,7 @@ Windows InfluxDB 1.x directions came [from here](https://portal.influxdata.com/d
 - Run `influxd.exe`
 - [Post setup](influxdb.md#post-setup) configuration
 
-(Default install path: 'C:\Program Files\InfluxData\influxdb\')
+Default install path: 'C:\Program Files\InfluxData\influxdb\'
 
 
 ### CentOS 7

--- a/documentation/docs/dependencies/influxdb.md
+++ b/documentation/docs/dependencies/influxdb.md
@@ -23,7 +23,7 @@ Using Power Shell (Run as Administrator)
 wget https://dl.influxdata.com/influxdb/releases/influxdb-1.8.10_windows_amd64.zip -UseBasicParsing -OutFile influxdb-1.8.10_windows_amd64.zip
 Expand-Archive .\influxdb-1.8.10_windows_amd64.zip -DestinationPath 'C:\Program Files\InfluxData\influxdb\'
 ```
-InfluxDB 1.x directions came [from here:](https://portal.influxdata.com/downloads/)
+Windows InfluxDB 1.x directions came [from here:](https://portal.influxdata.com/downloads/)
 
 ### CentOS 7
 

--- a/documentation/docs/dependencies/influxdb.md
+++ b/documentation/docs/dependencies/influxdb.md
@@ -29,7 +29,7 @@ Windows InfluxDB 1.x directions came [from here](https://portal.influxdata.com/d
 - Run `influxd.exe`
 - [Post setup](influxdb.md#post-setup) configuration
 
-Default install path: 'C:\Program Files\InfluxData\influxdb\'
+*Default install path: 'C:\Program Files\InfluxData\influxdb\'*
 
 
 ### CentOS 7

--- a/documentation/docs/dependencies/influxdb.md
+++ b/documentation/docs/dependencies/influxdb.md
@@ -23,7 +23,6 @@ Using Power Shell (Run as Administrator)
 wget https://dl.influxdata.com/influxdb/releases/influxdb-1.8.10_windows_amd64.zip -UseBasicParsing -OutFile influxdb-1.8.10_windows_amd64.zip
 Expand-Archive .\influxdb-1.8.10_windows_amd64.zip -DestinationPath 'C:\Program Files\InfluxData\influxdb\'
 ```
--or-
 InfluxDB 1.x directions came [from here:](https://portal.influxdata.com/downloads/)
 
 ### CentOS 7

--- a/documentation/docs/install/cloudkey.md
+++ b/documentation/docs/install/cloudkey.md
@@ -56,12 +56,12 @@ For InfluxDB on a CloudKey it is *highly* advisable to add a retention policy to
 prevent the database from growing in uncontrollably.
 :::
 
-#### Install UniFi Poller
+#### Install Unpoller
 
 Linux repository hosting provided by
 [![packagecloud](https://docs.golift.io/integrations/packagecloud-full.png "PackageCloud.io")](http://packagecloud.io)
 
-Install the Go Lift package repo and UniFi Poller with this command:
+Install the Go Lift package repo and Unpoller with this command:
 
 ```shell
 curl -s https://golift.io/repo.sh | sudo bash -s - unifi-poller
@@ -71,7 +71,7 @@ curl -s https://golift.io/repo.sh | sudo bash -s - unifi-poller
 
 There is an existing suite for installing `podman` containers to run on `unifios` -
 see [here](https://github.com/boostchicken/udm-utilities).  At the time of writing  we are not
-aware of any use implementing UniFi Poller  using this method, but it should be straightforward.
+aware of any user implementing Unpoller using this method, but it should be straightforward.
 
 ## Configuration
 

--- a/documentation/docs/install/configuration.md
+++ b/documentation/docs/install/configuration.md
@@ -21,7 +21,8 @@ the advantage that UniFi Poller specific settings can be saved in the same share
 Docker folder as other app's data. **Normally native installs use a
 configuration file and Docker installations use environment variables.**
 
-An example is included in the Unpoller install folder `up.conf.example` you can edit it and then renamed it to `up.conf`
+An example is included in the Unpoller install folder `up.conf.example`
+You can edit the file in a text editor and then rename it to `up.conf`
 
 The variables to be set can be split into three categories:
 

--- a/documentation/docs/install/configuration.md
+++ b/documentation/docs/install/configuration.md
@@ -21,8 +21,8 @@ the advantage that UniFi Poller specific settings can be saved in the same share
 Docker folder as other app's data. **Normally native installs use a
 configuration file and Docker installations use environment variables.**
 
-An example is included in the Unpoller install folder `up.conf.example` 
-You can edit the file in a text editor and then rename it to `up.conf`
+An example is included in the Unpoller install folder `up.conf.example`. 
+You can edit the file in a text editor and then rename it to `up.conf`.
 
 The variables to be set can be split into three categories:
 

--- a/documentation/docs/install/configuration.md
+++ b/documentation/docs/install/configuration.md
@@ -21,6 +21,8 @@ the advantage that UniFi Poller specific settings can be saved in the same share
 Docker folder as other app's data. **Normally native installs use a
 configuration file and Docker installations use environment variables.**
 
+An example is included in the Unpoller install folder `up.conf.example` you can edit it and then renamed it to `up.conf`
+
 The variables to be set can be split into three categories:
 
 1. Configuration of UniFi Poller itself.
@@ -32,7 +34,7 @@ The variables to be set can be split into three categories:
 
 More documentation on the configuration options is included in the
 [example configuration file](https://github.com/unifi-poller/unifi-poller/blob/master/examples/up.conf.example)
-in the main Github repo.
+in the main Github repo. You can copy it to make your own `up.conf` file.
 
 The following sections break down the various configuration options available
 for the three main categories mentioned previously.

--- a/documentation/docs/install/configuration.md
+++ b/documentation/docs/install/configuration.md
@@ -21,8 +21,7 @@ the advantage that UniFi Poller specific settings can be saved in the same share
 Docker folder as other app's data. **Normally native installs use a
 configuration file and Docker installations use environment variables.**
 
-An example is included in the Unpoller install folder `up.conf.example`. 
-You can edit the file in a text editor and then rename it to `up.conf`.
+An example is included in the Unpoller install folder `XXX.example`. You can edit the file in a text editor and then rename it removing `.example`. To create a valid file.
 
 The variables to be set can be split into three categories:
 

--- a/documentation/docs/install/configuration.md
+++ b/documentation/docs/install/configuration.md
@@ -21,7 +21,7 @@ the advantage that UniFi Poller specific settings can be saved in the same share
 Docker folder as other app's data. **Normally native installs use a
 configuration file and Docker installations use environment variables.**
 
-An example is included in the Unpoller install folder `up.conf.example`
+An example is included in the Unpoller install folder `up.conf.example` 
 You can edit the file in a text editor and then rename it to `up.conf`
 
 The variables to be set can be split into three categories:

--- a/documentation/docs/install/configuration.md
+++ b/documentation/docs/install/configuration.md
@@ -21,7 +21,7 @@ the advantage that UniFi Poller specific settings can be saved in the same share
 Docker folder as other app's data. **Normally native installs use a
 configuration file and Docker installations use environment variables.**
 
-An example is included in the Unpoller install folder `XXX.example`. You can edit the file in a text editor and then rename it removing `.example`. To create a valid file.
+An example is included in the Unpoller install folder `up.xxxx.example`. You can edit the file in a text editor and then rename it removing `.example`. To create a valid file.
 
 The variables to be set can be split into three categories:
 

--- a/documentation/docs/install/configuration.md
+++ b/documentation/docs/install/configuration.md
@@ -89,7 +89,6 @@ When configuring make sure that you do **not** include `:8443` on the url of the
 if you are using `unifios`. Those are: UDM Pro, UDM, UXG, or CkoudKey with recent firmware.
 :::
 
-#### Unifi Section Example
 Most `unifi` configuration will look like this:
 
 ```toml
@@ -184,7 +183,6 @@ This section begins with ``[influxdb]`` and configures a single InfluxDB write d
 |UP_INFLUXDB_PASS |influxdb.pass |`"unifipoller"` password for username|
 |UP_INFLUXDB_INTERVAL |influxdb.interval|`"30s"` how often to poll and collect metrics, ie "1m" or "90s"|
 
-#### InfluxDB Example
 InfluxDB is very easy to use with UniFi Poller, and it's recommend if this whole
 metrics ecosystem is new to you. All you do is add a small configuration like you
 see below and poller sends all your glorious data into the database.

--- a/documentation/docs/install/configuration.md
+++ b/documentation/docs/install/configuration.md
@@ -89,6 +89,7 @@ When configuring make sure that you do **not** include `:8443` on the url of the
 if you are using `unifios`. Those are: UDM Pro, UDM, UXG, or CkoudKey with recent firmware.
 :::
 
+#### Unifi Section Example
 Most `unifi` configuration will look like this:
 
 ```toml
@@ -183,6 +184,7 @@ This section begins with ``[influxdb]`` and configures a single InfluxDB write d
 |UP_INFLUXDB_PASS |influxdb.pass |`"unifipoller"` password for username|
 |UP_INFLUXDB_INTERVAL |influxdb.interval|`"30s"` how often to poll and collect metrics, ie "1m" or "90s"|
 
+#### InfluxDB Example
 InfluxDB is very easy to use with UniFi Poller, and it's recommend if this whole
 metrics ecosystem is new to you. All you do is add a small configuration like you
 see below and poller sends all your glorious data into the database.

--- a/documentation/docs/install/controllerlogin.md
+++ b/documentation/docs/install/controllerlogin.md
@@ -1,0 +1,25 @@
+---
+id: controllerlogin
+title: Unifi Controller Login
+---
+
+## Configuring the Unifi controller
+
+The only requirement of the controller is that UniFi Poller can log in to it and extract data.
+For this purpose go ahead and create a new user now. Make a note of the username and password you have chosen.
+
+If your controller is on a UDM, UXG, or UDM-Pro or UCK running UnifiOS then it is recommended that a
+Limited Admin user is created with Read-Only rights to the UniFi Network app. Other access
+levels may not work correctly.
+
+For example,the screenshot below show the username chosen as `unifipoller`.
+This is the default, will be used throughout these docs.
+
+![img](../../static/img/UDM_user.png)
+
+If you are using another controller type (eg. Cloudkey or Virtual) then create a read-only user.
+
+## Next Steps
+[Installation Overview](overview)
+
+- [Create Config](applicationconfig)

--- a/documentation/docs/install/controllerlogin.md
+++ b/documentation/docs/install/controllerlogin.md
@@ -6,7 +6,11 @@ title: Unifi Controller Login
 ## Configuring the Unifi controller
 
 The only requirement of the controller is that UniFi Poller can log in to it and extract data.
-For this purpose go ahead and create a new user now. Make a note of the username and password you have chosen.
+For this purpose go ahead and create a new user. Make a note of the username and password you have chosen.
+
+Adding a user depends on the type of controller you have.
+
+### UnifiOS Controller
 
 If your controller is on a UDM, UXG, or UDM-Pro or UCK running UnifiOS then it is recommended that a
 Limited Admin user is created with Read-Only rights to the UniFi Network app. Other access
@@ -17,7 +21,13 @@ This is the default, will be used throughout these docs.
 
 ![img](../../static/img/UDM_user.png)
 
-If you are using another controller type (eg. Cloudkey or Virtual) then create a read-only user.
+### Non UnifiOS Controller
+
+If you are using another controller type (eg. Cloudkey or Virtual) then create a menual read-only user.
+
+The `Email` field will be the 'username' you will need to create the config file.
+
+The Unifi controller currently requires the email be formated correctly. If you don't have your own domain try using @example.com so you don't inadvertantly give access to a random user.
 
 ## Next Steps
 [Installation Overview](overview)

--- a/documentation/docs/install/docker.md
+++ b/documentation/docs/install/docker.md
@@ -3,11 +3,11 @@ id: docker
 title: Docker
 ---
 
-This page assumes that you have decided to start UniFi Poller with Docker using the command line.
+This page assumes that you have decided to start Unpoller with Docker using the command line.
 
 ## First
 
-Make sure you have set up a user on your controller for UniFi Poller to poll. You must have
+Make sure you have set up a user on your controller for Unpoller to poll. You must have
 a working (and supported) version of [Grafana](../dependencies/grafana) and at
 least one of [InfluxDB](../dependencies/influxDB) or [Prometheus](../dependencies/prometheus).
 If you don't have them, follow these instructions for installing
@@ -29,7 +29,7 @@ Details of tags available are described in [Docker - FAQ](../help/docker_faq).
 
 ## Container Configuration
 
-UniFi Poller's Docker container can be configured in two ways:
+Unpoller's Docker container can be configured in two ways:
 
 1. Using environment variables.
 1. Using a configuration file.

--- a/documentation/docs/install/dockercompose.md
+++ b/documentation/docs/install/dockercompose.md
@@ -3,31 +3,31 @@ id: dockercompose
 title: Docker Compose
 ---
 
-This page assumes that you have decided to start UniFi Poller using `docker-compose`.
-The setup detailed below will install containers for UniFi Poller, Grafana and InfluxDB
+This page assumes that you have decided to start Unpoller using `docker-compose`.
+The setup detailed below will install containers for Unpoller, Grafana and InfluxDB
 
 ## First
 
-Make sure you have [set up a user](unifilogin) on your controller for UniFi Poller. 
+Make sure you have [set up a user](unifilogin) on your controller for Unpoller. 
 
 ---
 
 ## Installation
 
-UniFi Poller's Docker container can be configured in two ways:
+Unpoller's Docker container can be configured in two ways:
 
 1. Using environment variables.
 1. Using a configuration file.
 
 Which to use is a matter of personal choice. The environmental path has the advantage that
 all settings are in one place (albeit a hidden file, and one where all information is available
-to all containers). The config file method has the advantage that UniFi Poller specific
+to all containers). The config file method has the advantage that Unpoller specific
 settings can be saved in the same shared Docker folder as the rest of the app's data.
 
 There is a detailed description of the configuration parameters on the
 [Application Configuration](../install/configuration) page.
 
-Both of the alternatives described here will pull containers not just for UniFi Poller,
+Both of the alternatives described here will pull containers not just for Unpoller,
 but also for InfluxDB and Grafana. If you wish to use existing instances then amend the files as necessary.
 
 ### Using Environment Variables
@@ -56,13 +56,13 @@ This example is advanced, for demonstration only, and not recommend for newbies.
 
 ---
 
-The following example illustrates launching Grafana, Prometheus and UniFi Poller with docker compose.
+The following example illustrates launching Grafana, Prometheus and Unpoller with docker compose.
 This does not utilize a `.env` file nor a configuration file and instead puts all the env variables
 directly into the docker-compose file.
 This still requires a [Prometheus configuration](../dependencies/prometheus) to scrape Poller.
 
 :::note
-This is a [community provided](https://github.com/unifi-poller/unifi-poller/issues/309#issuecomment-796870916)
+This is a [community provided](https://github.com/unpoller/unpoller/issues/309#issuecomment-796870916)
 example.
 :::
 
@@ -122,7 +122,7 @@ volumes:
 
 Alternatively, if you choose to use a configuration file:
 
-- Copy the example [config file](https://github.com/unifi-poller/unifi-poller/blob/master/examples/up.conf.example)
+- Copy the example [config file](https://github.com/unpoller/unpoller/blob/master/examples/up.conf.example)
 - Edit it as necessary (in particular ensure that the `[unifi]`/`user` and `pass` variables are set)
 - In the `[influxdb]` section change ``url  = "http://127.0.0.1:8086"`` to become
   `url  = "http://THE_IP_OF_YOUR_DOCKER_HOST:8086"`

--- a/documentation/docs/install/dockercompose.md
+++ b/documentation/docs/install/dockercompose.md
@@ -8,7 +8,7 @@ The setup detailed below will install containers for UniFi Poller, Grafana and I
 
 ## First
 
-Make sure you have set up a user on your controller for UniFi Poller.
+Make sure you have [set up a user](unifilogin) on your controller for UniFi Poller. 
 
 ---
 

--- a/documentation/docs/install/grafana.md
+++ b/documentation/docs/install/grafana.md
@@ -18,11 +18,11 @@ The following explains the steps for InfluxDB; the Prometheus steps are very sim
 - Click `Add your first data source` on the home page you see after login.
 - Select the InfluxDB option
 - Set the following fields:
--        Name = `UniFi InfluxDB` (or whatever name you want) and set to default
--        URL = `http://influxdb1:8086`
--        Database = `unifi`
--        Username = `unifipoller`
--        Password = `unifipoller`
+- - Name = `UniFi InfluxDB` (or whatever name you want) and set to default
+- - URL = `http://influxdb1:8086`
+- - Database = `unifi`
+- - Username = `unifipoller`
+- - Password = `unifipoller`
 - No other fields need to be changed or set on this page.
 - Click `Save & Test`
 - You should get green banner above the save and test that says 'Data Source is Working'

--- a/documentation/docs/install/grafana.md
+++ b/documentation/docs/install/grafana.md
@@ -19,7 +19,7 @@ The following explains the steps for InfluxDB; the Prometheus steps are very sim
 - Select the InfluxDB option
 - Set the following fields:
 - - Name = `UniFi InfluxDB` (or whatever name you want) and set to default
-- - URL = `http://influxdb1:8086`
+- - URL = `http://influxdb1:8086` or `http://localhost:8086`
 - - Database = `unifi`
 - - Username = `unifipoller`
 - - Password = `unifipoller`

--- a/documentation/docs/install/grafana.md
+++ b/documentation/docs/install/grafana.md
@@ -18,11 +18,11 @@ The following explains the steps for InfluxDB; the Prometheus steps are very sim
 - Click `Add your first data source` on the home page you see after login.
 - Select the InfluxDB option
 - Set the following fields:
-        Name = UniFi InfluxDB (or whatever name you want) and set to default
-        URL = `http://influxdb1:8086`
-        Database = `unifi`
-        Username = `unifipoller`
-        Password = `unifipoller`
+-        Name = `UniFi InfluxDB` (or whatever name you want) and set to default
+-        URL = `http://influxdb1:8086`
+-        Database = `unifi`
+-        Username = `unifipoller`
+-        Password = `unifipoller`
 - No other fields need to be changed or set on this page.
 - Click `Save & Test`
 - You should get green banner above the save and test that says 'Data Source is Working'

--- a/documentation/docs/install/grafana.md
+++ b/documentation/docs/install/grafana.md
@@ -53,7 +53,7 @@ the changes, and apply them to your own custom dashboards.
       and copying graphs out of them.
     - This also allows you to identify problems with them and open an Issue.
 
-### Dashboards Instructions
+### Dashboard Installation Instructions
 
 - Simply click the + on the left nav bar in Grafana and click Import.
 - Put in the ID for the dashboard (below) and click the blue Load button.

--- a/documentation/docs/install/installmethod.md
+++ b/documentation/docs/install/installmethod.md
@@ -42,7 +42,7 @@ Some devices have specific install methods
 
 - unRAID Template -- An unRAID Template is available in the Community Applications.
 - [Synology](Synology) -- Via Docker Image
-- [CloudKey](cloudkey) -- You may also install directly on a [CloudKey](cloudkey), but that's an advanced setup and not generally recommended.
+- [CloudKey](cloudkey) -- You may also install directly on a CloudKey, but that's an advanced setup and not generally recommended.
 
 ## Next Steps
 [Installation Overview](overview)

--- a/documentation/docs/install/installmethod.md
+++ b/documentation/docs/install/installmethod.md
@@ -48,6 +48,3 @@ Some devices have specific install methods
 [Installation Overview](overview)
 
 - [Setup controller login for Unpoller](controllerlogin)
-- [Create Config](applicationconfig)
-- Install Unpoller Suite
-- [Setup Grafana](grafana)

--- a/documentation/docs/install/installmethod.md
+++ b/documentation/docs/install/installmethod.md
@@ -38,7 +38,7 @@ Install each of the components individually
 - Requires manual configuration
 
 ### Device Specific
-Some devices have specific install methods
+Some devices have specific install methods. If you have one of those devices the instructions for that device take precedence.
 
 - unRAID Template -- An unRAID Template is available in the Community Applications.
 - [Synology](Synology) -- Via Docker Image

--- a/documentation/docs/install/installmethod.md
+++ b/documentation/docs/install/installmethod.md
@@ -7,7 +7,7 @@ title: Install Method
 
 There are two main methods to install the Unpollor 'suite' (Unpoller and accociated programs)
 
-### Docker image
+### Docker Image
 This is the recommended way to install and the best option for new users.
 
 #### Advantages of Docker
@@ -44,44 +44,10 @@ Some devices have specific install methods
 - [Synology](Synology) -- Via Docker Image
 - [CloudKey](cloudkey) -- You may also install directly on a [CloudKey](cloudkey), but that's an advanced setup and not generally recommended.
 
-## Installation Overview
-If you prefer you can keep this page open as you walk though the installion steps.
+## Next Steps
+[Installation Overview](overview)
 
-### 1) Setup Unifi login for Unpoller
-No matter which method of installation you choose you will need to give Unpoller a way to access the infomation in your controller.
-You can setup Unpoller to get information from multiple controllers if you want, however we recommend getting one controller working before linking multiple.
-
-[Adding a login for Unpoller](unifilogin)
-
-### 2) Create Config
-The config tells Unpoller where to find the Unifi controller(s), database, and other infomation.
-(If you are doing a Manual installation you may need some information from step 3 to compleate the config.)
-
-[Creating/Modifiing Config](applicationconfig)
-
-### 3) Install Unpoller Suite
-#### Option 1 - Using a Docker image
-
-- [Installing via docker-compose](dockercompose)
-- [Installing via command line](docker)
-
-#### Option 2 - Manual installation
-
-**Install Database:**
-[InfluxDB](../dependencies/influxdb) and [Prometheus](../dependencies/prometheus) are both supported. You only need one.
-
-InfluxDB is recomended, as it supports both metrics and logging.
-Prometheus can hold only metrics. Loki is made by the Devs of Prometheus to hold logs. If you want both metrics & logging you will need to install Loki alongside Prometheus.
-
-**Install Grafana:**
-[Grafana Installation](Grafana)
-
-**Install Unpoller:**
-Platform specific install docs:
-- [Windows](windows)
-- [MacOS](macos)
-- [Linux](linux)
-- [FreeBSD](freebsd)
-
-### 4) Setup Grafana
-Setup Grafana
+- [Setup controller login for Unpoller](controllerlogin)
+- [Create Config](applicationconfig)
+- Install Unpoller Suite
+- [Setup Grafana](grafana)

--- a/documentation/docs/install/installmethod.md
+++ b/documentation/docs/install/installmethod.md
@@ -40,10 +40,9 @@ Install each of the components individually
 ### Device Specific
 Some devices have specific install methods
 
-- unRAID Template
--- An unRAID Template is available in the Community Applications.
-- CloudKey
--- You may also install directly on a [CloudKey](cloudkey), but that's an advanced setup and not generally recommended.
+- unRAID Template -- An unRAID Template is available in the Community Applications.
+- [Synology](Synology) -- Via Docker Image
+- [CloudKey](cloudkey) -- You may also install directly on a [CloudKey](cloudkey), but that's an advanced setup and not generally recommended.
 
 ## Installation Overview
 If you prefer you can keep this page open as you walk though the installion steps.

--- a/documentation/docs/install/installmethod.md
+++ b/documentation/docs/install/installmethod.md
@@ -30,7 +30,7 @@ Install each of the components individually
 - Works on systems that don't support Docker
 - You can make use of any components you already have
 - Less performance impact
-- Don't need VM support
+- Don't need hardware VM support
 
 #### Disadvantages of Manual
 

--- a/documentation/docs/install/overview.md
+++ b/documentation/docs/install/overview.md
@@ -3,6 +3,7 @@ If you prefer you can keep this page open as you walk though the installation st
 
 ### 1) Choose an Installation Method
 
+
 [Chosing an Install Method](installmethod)
 
 ### 2) Setup Unifi login for Unpoller
@@ -32,7 +33,7 @@ InfluxDB is recomended, as it supports both metrics and logging.
 Prometheus can hold only metrics. Loki is made by the Devs of Prometheus to hold logs. If you want both metrics & logging you will need to install Loki alongside Prometheus.
 
 **Install Grafana:**
-[Grafana Installation](Grafana)
+[Grafana Installation](grafana)
 
 **Install Unpoller:**
 Platform specific install docs:

--- a/documentation/docs/install/overview.md
+++ b/documentation/docs/install/overview.md
@@ -55,13 +55,13 @@ Platform specific install docs:
 
 ### You're Done!
 
-Or maybe it isn't working check for [Common Problems](../help/common)
-
-Please contact us on [Discord](https://golift.io/discord) if you need any help.
-Or try [this](https://community.ui.com/questions/UniFi-Poller-Store-UniFi-Controller-Metrics-in-Prometheus-or-InfluxDB/58a0ea34-d2b3-41cd-93bb-d95d3896d1a1)
+If you're having issues:
+- Check for some [Common Problems](../help/common)
+- If you have question regarding Docker check out the [Docker FAQ](../help/docker_faq)
+- Contact us on [Discord](https://golift.io/discord)
+- Or try [this](https://community.ui.com/questions/UniFi-Poller-Store-UniFi-Controller-Metrics-in-Prometheus-or-InfluxDB/58a0ea34-d2b3-41cd-93bb-d95d3896d1a1)
 thread on the UI community.
-
-Alternatively, raise an [issue](https://github.com/unifi-poller/unifi-poller/issues) on Github.
+- Alternatively, raise an [issue](https://github.com/unifi-poller/unifi-poller/issues) on Github.
 
 ### Customization and Advanced Setup
 

--- a/documentation/docs/install/overview.md
+++ b/documentation/docs/install/overview.md
@@ -4,11 +4,11 @@ title: Installation Overview
 ---
 
 ## Installation Overview
-If you prefer you can keep this page open as you walk though the installation steps of the Unpoller Suite.
+If you prefer you can keep this page open as you walk though the installation steps of the Unpoller suite.
 
 The Unpoller suite allows you to collect data from your UniFi network controller, save it to a database, and then display it on pre-supplied attractive and data-rich Grafana dashboards
 
-The 'suite' consit of three main programs that work togather.
+The 'suite' consists of three main programs that work togather.
 UnPoller itself --> The Database --> Grafana viewer dashboards
 
 For more information check out [how it works](../poller/howitworks).

--- a/documentation/docs/install/overview.md
+++ b/documentation/docs/install/overview.md
@@ -29,8 +29,8 @@ The config tells Unpoller where to find the Unifi controller(s), database, and o
 - [Installing via docker-compose](dockercompose)
 - [Installing via command line](docker)
 
-#### Option 2 - Manual installation
-
+<details>
+  <summary>#### Option 2 - Manual installation</summary>
 **Install Database:**
 [InfluxDB](../dependencies/influxdb) and [Prometheus](../dependencies/prometheus) are both supported. You only need one.
 
@@ -47,5 +47,7 @@ Platform specific install docs:
 - [Linux](linux)
 - [FreeBSD](freebsd)
 
+<details>
+  
 ### 5) Setup Grafana
 Setup Grafana

--- a/documentation/docs/install/overview.md
+++ b/documentation/docs/install/overview.md
@@ -3,7 +3,7 @@ If you prefer you can keep this page open as you walk though the installion step
 
 ### 1) Choose an Installation Method
 
-[Chosing an Install Method]
+[Chosing an Install Method](installmethod)
 
 ### 2) Setup Unifi login for Unpoller
 No matter which method of installation you choose you will need to give Unpoller a way to access the infomation in your controller.

--- a/documentation/docs/install/overview.md
+++ b/documentation/docs/install/overview.md
@@ -57,7 +57,7 @@ Platform specific install docs:
 - [FreeBSD](freebsd)
 
 </details>
-  
+
 ### 5) Setup Grafana
 [Setup Grafana](grafana)
 

--- a/documentation/docs/install/overview.md
+++ b/documentation/docs/install/overview.md
@@ -1,5 +1,5 @@
 ## Installation Overview
-If you prefer you can keep this page open as you walk though the installion steps.
+If you prefer you can keep this page open as you walk though the installation steps.
 
 ### 1) Choose an Installation Method
 

--- a/documentation/docs/install/overview.md
+++ b/documentation/docs/install/overview.md
@@ -9,7 +9,7 @@ If you prefer you can keep this page open as you walk though the installation st
 ### 1) Choose an Installation Method
 
 
-[Chosing an Install Method](installmethod)
+[Chosing an Install Method](../install/installmethod)
 
 ### 2) Setup Unifi login for Unpoller
 No matter which method of installation you choose you will need to give Unpoller a way to access the infomation in your controller.

--- a/documentation/docs/install/overview.md
+++ b/documentation/docs/install/overview.md
@@ -1,3 +1,8 @@
+---
+id: overview
+title: Installation Overview
+---
+
 ## Installation Overview
 If you prefer you can keep this page open as you walk though the installation steps.
 

--- a/documentation/docs/install/overview.md
+++ b/documentation/docs/install/overview.md
@@ -29,7 +29,7 @@ You can setup Unpoller to get information from multiple controllers if you want,
 The config tells Unpoller where to find the Unifi controller(s), database, and other infomation.
 (If you are doing a Manual installation you may need some information from Step-4 to complete the config.)
 
-[Creating/Modifying Config](applicationconfig)
+[Creating/Modifying Config](configuration.md)
 
 ### 4) Install Unpoller Suite
 Option 1 - Using a Docker image

--- a/documentation/docs/install/overview.md
+++ b/documentation/docs/install/overview.md
@@ -21,7 +21,7 @@ You can setup Unpoller to get information from multiple controllers if you want,
 The config tells Unpoller where to find the Unifi controller(s), database, and other infomation.
 (If you are doing a Manual installation you may need some information from step 3 to compleate the config.)
 
-[Creating/Modifiing Config](applicationconfig)
+[Creating/Modifying Config](applicationconfig)
 
 ### 4) Install Unpoller Suite
 #### Option 1 - Using a Docker image

--- a/documentation/docs/install/overview.md
+++ b/documentation/docs/install/overview.md
@@ -24,13 +24,14 @@ The config tells Unpoller where to find the Unifi controller(s), database, and o
 [Creating/Modifying Config](applicationconfig)
 
 ### 4) Install Unpoller Suite
-#### Option 1 - Using a Docker image
+Option 1 - Using a Docker image
 
 - [Installing via docker-compose](dockercompose)
 - [Installing via command line](docker)
 
 <details>
-  <summary>#### Option 2 - Manual installation</summary>
+  <summary>Option 2 - Manual installation</summary>
+
 **Install Database:**
 [InfluxDB](../dependencies/influxdb) and [Prometheus](../dependencies/prometheus) are both supported. You only need one.
 
@@ -47,7 +48,7 @@ Platform specific install docs:
 - [Linux](linux)
 - [FreeBSD](freebsd)
 
-<details>
+</details>
   
 ### 5) Setup Grafana
 Setup Grafana

--- a/documentation/docs/install/overview.md
+++ b/documentation/docs/install/overview.md
@@ -57,7 +57,7 @@ Platform specific install docs:
 
 If you're having issues:
 - Check for some [Common Problems](../help/common)
-- If you have question regarding Docker check out the [Docker FAQ](../help/docker_faq)
+- If you have questions regarding Docker check out the [Docker FAQ](../help/docker_faq)
 - Contact us on [Discord](https://golift.io/discord)
 - Or try [this](https://community.ui.com/questions/UniFi-Poller-Store-UniFi-Controller-Metrics-in-Prometheus-or-InfluxDB/58a0ea34-d2b3-41cd-93bb-d95d3896d1a1)
 thread on the UI community.

--- a/documentation/docs/install/overview.md
+++ b/documentation/docs/install/overview.md
@@ -62,7 +62,6 @@ Platform specific install docs:
 [Setup Grafana](grafana)
 
 ### You're Done!
-
 If you're having issues:
 - Check for some [Common Problems](../help/common)
 - Check the [Unpoller FAQ](../poller/faq)
@@ -72,6 +71,11 @@ If you're having issues:
 thread on the UI community.
 - Alternatively, raise an [issue](https://github.com/unifi-poller/unifi-poller/issues) on Github.
 
-### Customization and Advanced Setup
 
+
+### Advanced Setup & Customization
+
+[Multiple Controllers](configuration.md#multiple-controllers)
+
+!!! Need to flush this out with links to Grafana guides to manipulating dashboards, presenting data, and any scraps of infomation we can find on the Unifi data that's being pulled.
 

--- a/documentation/docs/install/overview.md
+++ b/documentation/docs/install/overview.md
@@ -4,7 +4,15 @@ title: Installation Overview
 ---
 
 ## Installation Overview
-If you prefer you can keep this page open as you walk though the installation steps.
+If you prefer you can keep this page open as you walk though the installation steps of the Unpoller Suite.
+
+The Unpoller suite allows you to collect data from your UniFi network controller, save it to a database, and then display it on pre-supplied attractive and data-rich Grafana dashboards
+
+The 'suite' consit of three main programs that work togather.
+UnPoller itself --> The Database --> Grafana viewer dashboards
+
+For more information check out [how it works](../poller/howitworks).
+If you're ready to get started, follow our step by step install guide below.
 
 ### 1) Choose an Installation Method
 
@@ -57,6 +65,7 @@ Platform specific install docs:
 
 If you're having issues:
 - Check for some [Common Problems](../help/common)
+- Check the [Unpoller FAQ](../poller/faq)
 - If you have questions regarding Docker check out the [Docker FAQ](../help/docker_faq)
 - Contact us on [Discord](https://golift.io/discord)
 - Or try [this](https://community.ui.com/questions/UniFi-Poller-Store-UniFi-Controller-Metrics-in-Prometheus-or-InfluxDB/58a0ea34-d2b3-41cd-93bb-d95d3896d1a1)

--- a/documentation/docs/install/overview.md
+++ b/documentation/docs/install/overview.md
@@ -39,7 +39,7 @@ InfluxDB is recomended, as it supports both metrics and logging.
 Prometheus can hold only metrics. Loki is made by the Devs of Prometheus to hold logs. If you want both metrics & logging you will need to install Loki alongside Prometheus.
 
 **Install Grafana:**
-[Grafana Installation](grafana)
+[Grafana Installation](../dependencies/grafana)
 
 **Install Unpoller:**
 Platform specific install docs:
@@ -51,4 +51,4 @@ Platform specific install docs:
 </details>
   
 ### 5) Setup Grafana
-Setup Grafana
+[Setup Grafana](grafana)

--- a/documentation/docs/install/overview.md
+++ b/documentation/docs/install/overview.md
@@ -1,0 +1,45 @@
+## Installation Overview
+If you prefer you can keep this page open as you walk though the installion steps.
+
+### 1) Choose an Installation Method
+
+[Chosing an Install Method]
+
+### 2) Setup Unifi login for Unpoller
+No matter which method of installation you choose you will need to give Unpoller a way to access the infomation in your controller.
+You can setup Unpoller to get information from multiple controllers if you want, however we recommend getting one controller working before linking multiple.
+
+[Adding a login for Unpoller](unifilogin)
+
+### 3) Create Config
+The config tells Unpoller where to find the Unifi controller(s), database, and other infomation.
+(If you are doing a Manual installation you may need some information from step 3 to compleate the config.)
+
+[Creating/Modifiing Config](applicationconfig)
+
+### 4) Install Unpoller Suite
+#### Option 1 - Using a Docker image
+
+- [Installing via docker-compose](dockercompose)
+- [Installing via command line](docker)
+
+#### Option 2 - Manual installation
+
+**Install Database:**
+[InfluxDB](../dependencies/influxdb) and [Prometheus](../dependencies/prometheus) are both supported. You only need one.
+
+InfluxDB is recomended, as it supports both metrics and logging.
+Prometheus can hold only metrics. Loki is made by the Devs of Prometheus to hold logs. If you want both metrics & logging you will need to install Loki alongside Prometheus.
+
+**Install Grafana:**
+[Grafana Installation](Grafana)
+
+**Install Unpoller:**
+Platform specific install docs:
+- [Windows](windows)
+- [MacOS](macos)
+- [Linux](linux)
+- [FreeBSD](freebsd)
+
+### 5) Setup Grafana
+Setup Grafana

--- a/documentation/docs/install/overview.md
+++ b/documentation/docs/install/overview.md
@@ -52,3 +52,17 @@ Platform specific install docs:
   
 ### 5) Setup Grafana
 [Setup Grafana](grafana)
+
+### You're Done!
+
+Or maybe it isn't working check for [Common Problems](../help/common)
+
+Please contact us on [Discord](https://golift.io/discord) if you need any help.
+Or try [this](https://community.ui.com/questions/UniFi-Poller-Store-UniFi-Controller-Metrics-in-Prometheus-or-InfluxDB/58a0ea34-d2b3-41cd-93bb-d95d3896d1a1)
+thread on the UI community.
+
+Alternatively, raise an [issue](https://github.com/unifi-poller/unifi-poller/issues) on Github.
+
+### Customization and Advanced Setup
+
+

--- a/documentation/docs/install/overview.md
+++ b/documentation/docs/install/overview.md
@@ -27,7 +27,7 @@ You can setup Unpoller to get information from multiple controllers if you want,
 
 ### 3) Create Config
 The config tells Unpoller where to find the Unifi controller(s), database, and other infomation.
-(If you are doing a Manual installation you may need some information from step 3 to compleate the config.)
+(If you are doing a Manual installation you may need some information from Step-4 to complete the config.)
 
 [Creating/Modifying Config](applicationconfig)
 

--- a/documentation/docs/install/windows.md
+++ b/documentation/docs/install/windows.md
@@ -26,6 +26,8 @@ Drop a valid [config file](configuration) `up.conf` in the same directory, and y
 ```shell
 unifi-poller.amd64.exe -c up.conf
 ```
+As long as Unpoller is running it should be retreiving updated data from your controller.
+
 Please contact us on [Discord](https://golift.io/discord) if you need any help.
 
 ## Next Steps

--- a/documentation/docs/install/windows.md
+++ b/documentation/docs/install/windows.md
@@ -12,14 +12,16 @@ a working (and supported) version of [Grafana](../dependencies/grafana) and at
 least one of [InfluxDB](../dependencies/influxDB) or [Prometheus](../dependencies/prometheus).
 If you don't have them, follow these instructions for installing
 [InfluxDB](../dependencies/influxdb) and [Grafana](../dependencies/grafana).
+You can review the [installation overview](overview.md) if needed.
 
 ---
 
 ## Install
 
 As it is now, a pre-compiled windows binary (.exe) is provided on the
-[Releases](https://github.com/unifi-poller/unifi-poller/releases) page.
-Combine this with a valid config file and you can run this on Windows.
+[Releases](https://github.com/unifi-poller/unifi-poller/releases) page `unifi-poller.amd64.exe.zip`.
+Unzip the file where you would like to install Unpoller.
+Drop a valid config file `up.conf` in and you can run this on Windows.
 Please contact us on [Discord](https://golift.io/discord) if you need any help.
 
 ```shell

--- a/documentation/docs/install/windows.md
+++ b/documentation/docs/install/windows.md
@@ -32,7 +32,6 @@ if you are using `unifios`. Those are: UDM Pro, UDM, UXG, or CkoudKey with recen
 :::
 
 ## Next Steps
+[Installation Overview](overview)
 
-1. [Configure the Application](../install/configuration).
-1. Don't forget the [Grafana Plugins](../dependencies/grafana#plugins).
-1. Finish [Setting-up Grafana](../install/grafana).
+- [Setup Grafana](grafana)

--- a/documentation/docs/install/windows.md
+++ b/documentation/docs/install/windows.md
@@ -21,7 +21,7 @@ You can review the [installation overview](overview.md) if needed.
 As it is now, a pre-compiled windows binary (.exe) is provided on the
 [Releases](https://github.com/unifi-poller/unifi-poller/releases) page `unifi-poller.amd64.exe.zip`.
 Unzip the file where you would like to install Unpoller.
-Drop a valid config file `up.conf` in the same directory, and you can run this on Windows by using the following command:
+Drop a valid [config file](configuration) `up.conf` in the same directory, and you can run this on Windows by using the following command:
 
 ```shell
 unifi-poller.amd64.exe -c up.conf

--- a/documentation/docs/install/windows.md
+++ b/documentation/docs/install/windows.md
@@ -28,11 +28,6 @@ unifi-poller.amd64.exe -c up.conf
 ```
 Please contact us on [Discord](https://golift.io/discord) if you need any help.
 
-:::important
-When configuring make sure that you do **not** include `:8443` on the url of the controller
-if you are using `unifios`. Those are: UDM Pro, UDM, UXG, or CkoudKey with recent firmware.
-:::
-
 ## Next Steps
 [Installation Overview](overview)
 

--- a/documentation/docs/install/windows.md
+++ b/documentation/docs/install/windows.md
@@ -21,12 +21,12 @@ You can review the [installation overview](overview.md) if needed.
 As it is now, a pre-compiled windows binary (.exe) is provided on the
 [Releases](https://github.com/unifi-poller/unifi-poller/releases) page `unifi-poller.amd64.exe.zip`.
 Unzip the file where you would like to install Unpoller.
-Drop a valid config file `up.conf` in and you can run this on Windows.
-Please contact us on [Discord](https://golift.io/discord) if you need any help.
+Drop a valid config file `up.conf` in the same directory, and you can run this on Windows by using the following command:
 
 ```shell
-unifi-poller.exe -c up.conf
+unifi-poller.amd64.exe -c up.conf
 ```
+Please contact us on [Discord](https://golift.io/discord) if you need any help.
 
 :::important
 When configuring make sure that you do **not** include `:8443` on the url of the controller


### PR DESCRIPTION
Cleaned up a lot of missing or confusing documentation regarding the install process.

Added instructions for Windows that was missing in quite a few locations,

Also overhauled the installation process itself.
Added a 'Installation Overview' page to help users know the steps to creating a working installation for their particular setup. This would replace the 'Getting Started' page.
Broke out the Installation methods into it's own page to make it easy to see what the options are and make adding any additional options easier in the future.

New install flow broken down into 5 steps (See the 'Overview' page)

This gives the user a 'map' for the install process and a place to refer to if they get lost/confused about what to do next or simply need help.
