### PR TITLE
Docs updates

### DIFF
--- a/documentation/docs/advanced/api.md
+++ b/documentation/docs/advanced/api.md
@@ -36,7 +36,7 @@ $ curl unifi.poller:37288/api/v1/config | jq .
     "unifi": {
       "name": "unifi",
       "version": "v0.0.9",
-      "path": "github.com/unifi-poller/inputunifi"
+      "path": "github.com/unpoller/inputunifi"
     }
   },
   "malloc": 9353240,
@@ -44,20 +44,25 @@ $ curl unifi.poller:37288/api/v1/config | jq .
   "mtalloc": 33876272,
   "numgc": 1234,
   "outputs": {
+    "datadog": {
+      "name": "datadog",
+      "version": "v0.0.11",
+      "path": "github.com/unpoller/pkg/datadogunifi"
+    },
     "influxdb": {
       "name": "influxdb",
       "version": "v0.0.11",
-      "path": "github.com/unifi-poller/influxunifi"
+      "path": "github.com/unpoller/pkg/influxunifi"
     },
     "loki": {
       "name": "loki",
       "version": "v0.0.1",
-      "path": "github.com/unifi-poller/lokiunifi"
+      "path": "github.com/unpoller/pkg/lokiunifi"
     },
     "prometheus": {
       "name": "prometheus",
       "version": "v0.0.10",
-      "path": "github.com/unifi-poller/promunifi"
+      "path": "github.com/unpoller/pkg/promunifi"
     }
   },
   "pid": 1,
@@ -83,24 +88,29 @@ $ curl unifi.poller:37288/api/v1/config/plugins | jq .
     "unifi": {
       "name": "unifi",
       "version": "v0.0.9",
-      "path": "github.com/unifi-poller/inputunifi"
+      "path": "github.com/unpoller/pkg/inputunifi"
     }
   },
   "outputs": {
+    "datadog": {
+      "name": "datadog",
+      "version": "v0.0.11",
+      "path": "github.com/unpoller/pkg/datadogunifi"
+    },
     "influxdb": {
       "name": "influxdb",
       "version": "v0.0.11",
-      "path": "github.com/unifi-poller/influxunifi"
+      "path": "github.com/unpoller/pkg/influxunifi"
     },
     "loki": {
       "name": "loki",
       "version": "v0.0.1",
-      "path": "github.com/unifi-poller/lokiunifi"
+      "path": "github.com/unpoller/pkg/lokiunifi"
     },
     "prometheus": {
       "name": "prometheus",
       "version": "v0.0.10",
-      "path": "github.com/unifi-poller/promunifi"
+      "path": "github.com/unpoller/pkg/promunifi"
     }
   }
 }

--- a/documentation/docs/advanced/webserver.md
+++ b/documentation/docs/advanced/webserver.md
@@ -46,10 +46,10 @@ UP_WEBSERVER_ACCOUNTS_captain="$2a$04$a2XvB0gvTXW6d4rHUXQdduUDBrQB3/2lGTxZXQ32Sd
 
 ### Making a Password Hash
 
-Use `unifi-poller` to make a web server account password hash. Like this:
+Use `unpoller` to make a web server account password hash. Like this:
 
 ```console
-unifi-poller -e -
+unpoller -e -
 Enter Password:
 $2a$04$a2XvB0gvTXW6d4rHUXQdduUDBrQB3/2lGTxZXQ32Sd9hYDxrz.oHm
 ```
@@ -57,8 +57,8 @@ $2a$04$a2XvB0gvTXW6d4rHUXQdduUDBrQB3/2lGTxZXQ32Sd9hYDxrz.oHm
 Using Docker:
 
 ```shell
-docker pull golift/unifi-poller
-docker -it golift/unifi-poller -e -
+docker pull ghcr.io/unpoller/unpoller
+docker -it ghcr.io/unpoller/unpoller -e -
 Enter Password:
 $2a$04$yOE5zjJs2Gg0jsGQpE7j2ucKiNndUGEzpX6BsLoKl0hkxBvE81z8.
 ```
@@ -69,7 +69,7 @@ These are the advanced settings and their default values.
 
 ```toml
   port          = 37288
-  html_path     = "/usr/lib/unifi-poller/web"
+  html_path     = "/usr/lib/unpoller/web"
   ssl_cert_path = ""
   ssl_key_path  = ""
   max_events    = 200
@@ -77,7 +77,7 @@ These are the advanced settings and their default values.
 
 The default HTML path is installed by any package or the Official Golift Docker image.
 This usually does not need to be changed. Exceptions are BSD and macOS systems.
-The HTML path on these OSes is `/usr/local/lib/unifi-poller/web`, and you need to set it.
+The HTML path on these OSes is `/usr/local/lib/unpoller/web`, and you need to set it.
 
 An SSL listener may be enabled instead of standard HTTP by providing an SSL Cert File and Key File paths.
 

--- a/documentation/docs/dependencies/grafana.md
+++ b/documentation/docs/dependencies/grafana.md
@@ -10,25 +10,6 @@ Configuration is documented in [another page](../install/grafana).
 Grafana 7.4.0+ is recommended. Grafana 7.x or newer is required.
 :::
 
-## Plugins
-
-This application uses a few Grafana plugins. Install them. Grafana must be installed first, see below.
-
-- Clock
-- Discrete (InfluxDB only)
-- PieChart
-
-```shell
-grafana-cli plugins install grafana-clock-panel
-grafana-cli plugins install natel-discrete-panel
-grafana-cli plugins install grafana-piechart-panel
-```
-
-If you're running Grafana in Docker, pass this environment variable/value to Grafana to install the plugins:
-```shell
-GF_INSTALL_PLUGINS=grafana-clock-panel,natel-discrete-panel,grafana-piechart-panel
-```
-
 ## Installing
 
 :::note
@@ -36,6 +17,11 @@ You can find official instructions in the [Grafana Docs](https://grafana.com/doc
 :::
 
 This will set it up on localhost:3000 with admin/admin login.
+
+### Windows
+
+- [Install Grafana](https://grafana.com/docs/grafana/latest/installation/windows/)
+- [Install Plugins](grafana.md#plugins)
 
 ### Linux
 
@@ -83,6 +69,27 @@ grafana/grafana
 ```
 
 Replace `YOURLOCALPATH` with a location for the data Grafana needs to write to disk.
+
+
+## Plugins
+
+This application uses a few Grafana plugins. Install them. Grafana must be installed first, see below.
+
+- Clock
+- Discrete (InfluxDB only)
+- PieChart
+
+Using the Grafana CLI tool `grafana-cli` in the Grafana directory:
+```shell
+grafana-cli plugins install grafana-clock-panel
+grafana-cli plugins install natel-discrete-panel
+grafana-cli plugins install grafana-piechart-panel
+```
+
+If you're running Grafana in Docker, pass this environment variable/value to Grafana to install the plugins:
+```shell
+GF_INSTALL_PLUGINS=grafana-clock-panel,natel-discrete-panel,grafana-piechart-panel
+```
 
 ## Configuring
 

--- a/documentation/docs/dependencies/influxdb.md
+++ b/documentation/docs/dependencies/influxdb.md
@@ -16,6 +16,22 @@ There are no pre-built graphs to display the data it collects.
 
 ## Installation
 
+### Windows
+
+Using Power Shell (Run as Administrator)
+```shell
+wget https://dl.influxdata.com/influxdb/releases/influxdb-1.8.10_windows_amd64.zip -UseBasicParsing -OutFile influxdb-1.8.10_windows_amd64.zip
+Expand-Archive .\influxdb-1.8.10_windows_amd64.zip -DestinationPath 'C:\Program Files\InfluxData\influxdb\'
+```
+Windows InfluxDB 1.x directions came [from here](https://portal.influxdata.com/downloads/)
+
+**Start & configure:**
+- Run `influxd.exe`
+- [Post setup](influxdb.md#post-setup) configuration
+
+*Default install path: 'C:\Program Files\InfluxData\influxdb\'*
+
+
 ### CentOS 7
 
 Provided by community: https://github.com/unifi-poller/unifi-poller/issues/30

--- a/documentation/docs/dependencies/influxdb.md
+++ b/documentation/docs/dependencies/influxdb.md
@@ -34,7 +34,7 @@ Windows InfluxDB 1.x directions came [from here](https://portal.influxdata.com/d
 
 ### CentOS 7
 
-Provided by community: https://github.com/unifi-poller/unifi-poller/issues/30
+Provided by community: https://github.com/unpoller/unpoller/issues/30
 
 ### CentOS 8 / RHEL 8
 
@@ -42,7 +42,7 @@ Provided by community: https://computingforgeeks.com/how-to-install-influxdb-on-
 
 ### Ubuntu 18.04
 
-These directions came [from here](https://github.com/unifi-poller/unifi-poller/issues/26).
+These directions came [from here](https://github.com/unpoller/unpoller/issues/26).
 
 Install:
 

--- a/documentation/docs/dependencies/loki.md
+++ b/documentation/docs/dependencies/loki.md
@@ -58,7 +58,7 @@ timeout    = "10s"
 ```
 
 You can set a user and pass if your Loki instance requires auth. This currently only supports Basic Auth.
-Please open an [Issue](https://github.com/unifi-poller/unifi-poller/issues/) if you need support for something
+Please open an [Issue](https://github.com/unpoller/unpoller/issues/) if you need support for something
 else. Alternatively you can pass the Tenant ID header directly by setting `tenant_id`.
 If your Loki instance is using/behind an SSL proxy that has a valid SSL cert you may set `verify_ssl` to true.
 The recommended interval is `2m` but anything from `1m` to `15m` should work fine.
@@ -72,8 +72,8 @@ The Loki Docker logging driver if you don't have it installed.
 ```yaml
 version: '3.0'
 services:
-  unifi-poller:
-    container_name: unifi-poller
+  unpoller:
+    container_name: unpoller
     environment:
       UP_INFLUXDB_DISABLE: "true"
       UP_LOKI_URL: http://log01.tylephony.com:3100
@@ -89,7 +89,7 @@ services:
       UP_UNIFI_DEFAULT_SAVE_SITES: "true"
       UP_UNIFI_DEFAULT_URL: https://unifi.tylephony.com:443
       UP_UNIFI_DEFAULT_USER: unifipoller
-    image: golift/unifi-poller:2.0.2-beta1
+    image: ghcr.io/unpoller/unpoller:latest
     logging:
       driver: loki
       options:

--- a/documentation/docs/dependencies/prometheus.md
+++ b/documentation/docs/dependencies/prometheus.md
@@ -3,7 +3,7 @@ id: prometheus
 title: Prometheus
 ---
 
-This page explains how to configure Prometheus and UniFi-Poller.
+This page explains how to configure Prometheus and Unpoller.
 For help installing Prometheus you'll have to look elsewhere; that's not in this document.
 If you need help getting started,
 [InfluxDB](../dependencies/influxdb) is recommended.
@@ -20,10 +20,10 @@ Many changes were made to how one may configure a controller. This page only app
 
 Configure a single controller in `up.conf` (or using environment variables).
 See [Application Configuration](../install/configuration) and the
-[example config file](https://github.com/unifi-poller/unifi-poller/blob/master/examples/up.conf.example)
+[example config file](https://github.com/unpoller/unpoller/blob/master/examples/up.conf.example)
 for help with that.
 
-Then you simply point prometheus at unifi-poller using a config like this:
+Then you simply point prometheus at unpoller using a config like this:
 
 ```yaml
 scrape_configs:
@@ -44,15 +44,15 @@ This may require exposing ports or modifying firewalls.
 
 ## Multiple Controllers
 
-You can either configure the controllers in unifi-poller or poll them unconfigured.
+You can either configure the controllers in unpoller or poll them unconfigured.
 When polling unconfigured, you must enable dynamic.
 You can scrape multiple controllers in several ways. Here is a list of options:
 
 1. Set all controller user/passwords the same and pass in controller URLs from Prometheus.
    To do this, you set the username and password as the default in the unifi config.
-1. Configure each controller in unifi-poller and pass in urls from Prometheus.
+1. Configure each controller in unpoller and pass in urls from Prometheus.
    This allows them to have different usernames and passwords.
-1. **NOT Recommended:** Configure each controller in unifi-poller and configure
+1. **NOT Recommended:** Configure each controller in unpoller and configure
    prometheus as shown above in the Single Controller section. This is useful when you
    want to poll all the controllers at the same time from a single prometheus instance.
 
@@ -60,7 +60,7 @@ You can scrape multiple controllers in several ways. Here is a list of options:
 
 This describes approach 1 above.
 
-Using this approach all you need to configure for controllers in unifi-poller is the name
+Using this approach all you need to configure for controllers in unpoller is the name
 and password. Example below. Any settings you provide to [unifi.defaults] will be used
 for all controllers passed in from Prometheus. All other settings are optional.
 ```toml
@@ -87,7 +87,7 @@ UP_UNIFI_DEFAULT_PASS="unifipoller"
 This describes approach 2 above.
 
 Configure each controller in up.conf or using environment variables.
-When Prometheus scrapes from unifi-poller the poller will map the URL directly to the one configured
+When Prometheus scrapes from unpoller the poller will map the URL directly to the one configured
 in up.conf (or using env vars). Just make sure the url you put into the prometheus configuration
  matches the url put into the poller configuration.
 
@@ -138,7 +138,7 @@ scrape_configs:
        replacement: localhost:9130
 ```
 
-Replace `localhost` with the IP of your unifi-poller host, and replace `unifi.controller`
+Replace `localhost` with the IP of your unpoller host, and replace `unifi.controller`
 and another.controller with the IPs of your controllers.
 
 ### Final Approach, NOT Recommended

--- a/documentation/docs/help/docker_faq.md
+++ b/documentation/docs/help/docker_faq.md
@@ -5,7 +5,7 @@ title: Docker FAQ
 
 **Where are the Docker images?**
 
-Images are available on [Docker Hub](https://hub.docker.com/r/golift/unifi-poller/tags)
+Images are available on [GHCR.io](https://github.com/unpoller/unpoller/pkgs/container/unpoller)
 
 Linux images are available for `386`, `amd64`, `arm32v6` and `arm64v8` architectures.
 There is no need to specify an architecture tag, docker will pull the correct image
@@ -22,15 +22,15 @@ you've been overly warned.
 
 You can install a specific version by specifying a version like this:
 ```shell
-docker pull golift/unifi-poller:2.0.1
+docker pull ghcr.io/unpoller/unpoller:latest
 ```
 or minor version like this:
 ```shell
-docker pull golift/unifi-poller:2.0
+docker pull ghcr.io/unpoller/unpoller:latest
 ```
 or a major version like this:
 ```shell
-docker pull golift/unifi-poller:2
+docker pull ghcr.io/unpoller/unpoller:latest
 ```
 
 **How can I build from source?**
@@ -38,11 +38,11 @@ docker pull golift/unifi-poller:2
 You can build your own image from source.
 
 ```shell
-git clone https://github.com/unifi-poller/unifi-poller.git
-cd unifi-poller
-make docker
+git clone https://github.com/unpoller/unpoller.git
+cd unpoller
+make build
 ```
 
 This builds a 64-bit amd64 linux image from scratch. If you need another architecture,
 use the `docker build` command directly with a correct ``--build-arg`` flag.
-Examples [here](https://github.com/unifi-poller/unifi-poller/tree/master/init/docker/hooks).
+Examples [here](https://github.com/unpoller/unpoller/tree/master/init/docker/hooks).

--- a/documentation/docs/help/help.md
+++ b/documentation/docs/help/help.md
@@ -9,4 +9,4 @@ Discord server.
 Or [this](https://community.ui.com/questions/UniFi-Poller-Store-UniFi-Controller-Metrics-in-Prometheus-or-InfluxDB/58a0ea34-d2b3-41cd-93bb-d95d3896d1a1)
 thread on the UI community.
 
-Alternatively, raise an [issue](https://github.com/unifi-poller/unifi-poller/issues) on Github.
+Alternatively, raise an [issue](https://github.com/unpoller/unpoller/issues) on Github.

--- a/documentation/docs/help/manualbuild.md
+++ b/documentation/docs/help/manualbuild.md
@@ -2,19 +2,18 @@
 
 Recommend reading the note at the bottom if you're using a mac.
 
-1. Install [FPM](https://fpm.readthedocs.io/en/latest/installing.html)
 1. Install [Go](https://golang.org/doc/install)
+1. Install [GoReleaser](https://goreleaser.com/install/)
 1. Clone this repo and change your working directory to the checkout.
   ```shell
-  git clone https://github.com/unifi-poller/unifi-poller.git
-  cd unifi-poller
+  git clone https://github.com/unpoller/unpoller.git
+  cd unpoller
   ```
 1. Install local Golang dependencies:
   - Build a package (or two!):
-    + `make deb` will build a Debian package
-    + `make rpm` builds a RHEL package.
+    + `make build` will build all packages and image
   - Install it:
-    + `sudo dpkg -i *.deb || sudo rpm -Uvh *.rpm`
+    + `sudo dpkg -i dist/*.deb || sudo rpm -Uvh dist/*.rpm`
 
 ### Manual Build Notes
 
@@ -24,12 +23,11 @@ And if you're going to install Homebrew, or already have, you can simply
 do something like this to get your Go environment up and build the packages:
 
 ```shell
-brew install rpmbuild gnu-tar go dep
-sudo gem install --no-document fpm
+brew install rpmbuild gnu-tar go goreleaser/tap/goreleaser
 mkdir ~/go/{src,mod}
 export GOPATH=~/go
 cd ~go/src
-git clone https://github.com/unifi-poller/unifi-poller.git
-cd unifi-poller
+git clone https://github.com/unpoller/unpoller.git
+cd unpoller
 make rpm deb
  ```

--- a/documentation/docs/install/cloudkey.md
+++ b/documentation/docs/install/cloudkey.md
@@ -64,7 +64,7 @@ Linux repository hosting provided by
 Install the Go Lift package repo and Unpoller with this command:
 
 ```shell
-curl -s https://golift.io/repo.sh | sudo bash -s - unifi-poller
+curl -s https://golift.io/repo.sh | sudo bash -s - unpoller
 ```
 
 ### Current Firmware: `unifios`
@@ -75,7 +75,7 @@ aware of any user implementing Unpoller using this method, but it should be stra
 
 ## Configuration
 
-The config file is located at `/etc/unifi-poller/up.conf` and
+The config file is located at `/etc/unpoller/up.conf` and
 it is explained on the [Application Configuration](../install/configuration) page.
 
 ## Next Steps

--- a/documentation/docs/install/cloudkey.md
+++ b/documentation/docs/install/cloudkey.md
@@ -56,12 +56,12 @@ For InfluxDB on a CloudKey it is *highly* advisable to add a retention policy to
 prevent the database from growing in uncontrollably.
 :::
 
-#### Install UniFi Poller
+#### Install Unpoller
 
 Linux repository hosting provided by
 [![packagecloud](https://docs.golift.io/integrations/packagecloud-full.png "PackageCloud.io")](http://packagecloud.io)
 
-Install the Go Lift package repo and UniFi Poller with this command:
+Install the Go Lift package repo and Unpoller with this command:
 
 ```shell
 curl -s https://golift.io/repo.sh | sudo bash -s - unifi-poller
@@ -71,7 +71,7 @@ curl -s https://golift.io/repo.sh | sudo bash -s - unifi-poller
 
 There is an existing suite for installing `podman` containers to run on `unifios` -
 see [here](https://github.com/boostchicken/udm-utilities).  At the time of writing  we are not
-aware of any use implementing UniFi Poller  using this method, but it should be straightforward.
+aware of any user implementing Unpoller using this method, but it should be straightforward.
 
 ## Configuration
 

--- a/documentation/docs/install/configuration.md
+++ b/documentation/docs/install/configuration.md
@@ -21,6 +21,8 @@ the advantage that UniFi Poller specific settings can be saved in the same share
 Docker folder as other app's data. **Normally native installs use a
 configuration file and Docker installations use environment variables.**
 
+An example is included in the Unpoller install folder `up.xxxx.example`. You can edit the file in a text editor and then rename it removing `.example`. To create a valid file.
+
 The variables to be set can be split into three categories:
 
 1. Configuration of UniFi Poller itself.
@@ -32,7 +34,7 @@ The variables to be set can be split into three categories:
 
 More documentation on the configuration options is included in the
 [example configuration file](https://github.com/unifi-poller/unifi-poller/blob/master/examples/up.conf.example)
-in the main Github repo.
+in the main Github repo. You can copy it to make your own `up.conf` file.
 
 The following sections break down the various configuration options available
 for the three main categories mentioned previously.

--- a/documentation/docs/install/configuration.md
+++ b/documentation/docs/install/configuration.md
@@ -33,7 +33,7 @@ The variables to be set can be split into three categories:
     - Other outputs plugins can be created, but none exist currently.
 
 More documentation on the configuration options is included in the
-[example configuration file](https://github.com/unifi-poller/unifi-poller/blob/master/examples/up.conf.example)
+[example configuration file](https://github.com/unpoller/unpoller/blob/master/examples/up.conf.example)
 in the main Github repo. You can copy it to make your own `up.conf` file.
 
 The following sections break down the various configuration options available
@@ -60,7 +60,7 @@ debug = false
 Docker Example:
 
 ```shell
-docker run -e "UP_POLLER_DEBUG=true" -e "UP_POLLER_QUIET=false" golift/unifi-poller
+docker run -e "UP_POLLER_DEBUG=true" -e "UP_POLLER_QUIET=false" golift/unpoller
 ```
 
 ## UniFi Controller
@@ -114,7 +114,7 @@ docker run
   -e "UP_UNIFI_DEFAULT_PASS=unifip4assw0rd" \
   -e "UP_UNIFI_DEFAULT_SAVE_SITES=true" \
   -e "UP_UNIFI_DEFAULT_SITE_0=default" \
-  golift/unifi-poller
+  golift/unpoller
 ```
 
 ### Multiple Controllers
@@ -204,5 +204,5 @@ docker run
   -e "UP_INFLUXDB_INTERVAL=60s" \
   -e "UP_UNIFI_DEFAULT_URL=https://192.168.1.2"
   -e "UP_UNIFI_DEFAULT_PASS=unifipassw0rd"
-  golift/unifi-poller
+  golift/unpoller
 ```

--- a/documentation/docs/install/controllerlogin.md
+++ b/documentation/docs/install/controllerlogin.md
@@ -32,4 +32,4 @@ The Unifi controller currently requires the email be formated correctly. If you 
 ## Next Steps
 [Installation Overview](overview)
 
-- [Create Config](applicationconfig)
+- [Create Config](controllerlogin)

--- a/documentation/docs/install/controllerlogin.md
+++ b/documentation/docs/install/controllerlogin.md
@@ -1,0 +1,35 @@
+---
+id: controllerlogin
+title: Unifi Controller Login
+---
+
+## Configuring the Unifi controller
+
+The only requirement of the controller is that UniFi Poller can log in to it and extract data.
+For this purpose go ahead and create a new user. Make a note of the username and password you have chosen.
+
+Adding a user depends on the type of controller you have.
+
+### UnifiOS Controller
+
+If your controller is on a UDM, UXG, or UDM-Pro or UCK running UnifiOS then it is recommended that a
+Limited Admin user is created with Read-Only rights to the UniFi Network app. Other access
+levels may not work correctly.
+
+For example,the screenshot below show the username chosen as `unifipoller`.
+This is the default, will be used throughout these docs.
+
+![img](../../static/img/UDM_user.png)
+
+### Non UnifiOS Controller
+
+If you are using another controller type (eg. Cloudkey or Virtual) then create a menual read-only user.
+
+The `Email` field will be the 'username' you will need to create the config file.
+
+The Unifi controller currently requires the email be formated correctly. If you don't have your own domain try using @example.com so you don't inadvertantly give access to a random user.
+
+## Next Steps
+[Installation Overview](overview)
+
+- [Create Config](applicationconfig)

--- a/documentation/docs/install/docker.md
+++ b/documentation/docs/install/docker.md
@@ -3,11 +3,11 @@ id: docker
 title: Docker
 ---
 
-This page assumes that you have decided to start UniFi Poller with Docker using the command line.
+This page assumes that you have decided to start Unpoller with Docker using the command line.
 
 ## First
 
-Make sure you have set up a user on your controller for UniFi Poller to poll. You must have
+Make sure you have set up a user on your controller for Unpoller to poll. You must have
 a working (and supported) version of [Grafana](../dependencies/grafana) and at
 least one of [InfluxDB](../dependencies/influxDB) or [Prometheus](../dependencies/prometheus).
 If you don't have them, follow these instructions for installing
@@ -29,7 +29,7 @@ Details of tags available are described in [Docker - FAQ](../help/docker_faq).
 
 ## Container Configuration
 
-UniFi Poller's Docker container can be configured in two ways:
+Unpoller's Docker container can be configured in two ways:
 
 1. Using environment variables.
 1. Using a configuration file.

--- a/documentation/docs/install/docker.md
+++ b/documentation/docs/install/docker.md
@@ -20,7 +20,7 @@ If you don't have them, follow these instructions for installing
 First pull the image from Docker Hub using
 
 ```shell
-docker pull golift/unifi-poller
+docker pull golift/unpoller
 ```
 
 :::info
@@ -49,21 +49,21 @@ If you are using the command line and have decided to use environment variables 
 container using the following command (and pass in other environment variables you wish to).
 
 ```shell
-docker run -e UP_UNIFI_DEFAULT_PASS="your-secret-pasword"  golift/unifi-poller:latest
+docker run -e UP_UNIFI_DEFAULT_PASS="your-secret-pasword"  golift/unpoller:latest
 ```
 
 ### Using Configuration File
 
 If you choose to use a configuration file:
 
-- Copy this [example config file](https://github.com/unifi-poller/unifi-poller/blob/master/examples/up.conf.example)
+- Copy this [example config file](https://github.com/unpoller/unpoller/blob/master/examples/up.conf.example)
 - Edit it as necessary (in particular ensure that the `[unifi]`/`user` and `pass` variables are set)
-- Save it as `unifi-poller.conf` in the local location you use for Docker storage.
+- Save it as `unpoller.conf` in the local location you use for Docker storage.
 
 Start the container by running:
 
 ```shell
-docker run -v /your-local-location/unifi-poller.conf:/config/unifi-poller.conf golift/unifi-poller
+docker run -v /your-local-location/unpoller.conf:/config/unpoller.conf golift/unpoller
 ```
 
 :::note

--- a/documentation/docs/install/dockercompose.md
+++ b/documentation/docs/install/dockercompose.md
@@ -3,31 +3,31 @@ id: dockercompose
 title: Docker Compose
 ---
 
-This page assumes that you have decided to start UniFi Poller using `docker-compose`.
-The setup detailed below will install containers for UniFi Poller, Grafana and InfluxDB
+This page assumes that you have decided to start Unpoller using `docker-compose`.
+The setup detailed below will install containers for Unpoller, Grafana and InfluxDB
 
 ## First
 
-Make sure you have set up a user on your controller for UniFi Poller.
+Make sure you have [set up a user](unifilogin) on your controller for Unpoller. 
 
 ---
 
 ## Installation
 
-UniFi Poller's Docker container can be configured in two ways:
+Unpoller's Docker container can be configured in two ways:
 
 1. Using environment variables.
 1. Using a configuration file.
 
 Which to use is a matter of personal choice. The environmental path has the advantage that
 all settings are in one place (albeit a hidden file, and one where all information is available
-to all containers). The config file method has the advantage that UniFi Poller specific
+to all containers). The config file method has the advantage that Unpoller specific
 settings can be saved in the same shared Docker folder as the rest of the app's data.
 
 There is a detailed description of the configuration parameters on the
 [Application Configuration](../install/configuration) page.
 
-Both of the alternatives described here will pull containers not just for UniFi Poller,
+Both of the alternatives described here will pull containers not just for Unpoller,
 but also for InfluxDB and Grafana. If you wish to use existing instances then amend the files as necessary.
 
 ### Using Environment Variables
@@ -56,13 +56,13 @@ This example is advanced, for demonstration only, and not recommend for newbies.
 
 ---
 
-The following example illustrates launching Grafana, Prometheus and UniFi Poller with docker compose.
+The following example illustrates launching Grafana, Prometheus and Unpoller with docker compose.
 This does not utilize a `.env` file nor a configuration file and instead puts all the env variables
 directly into the docker-compose file.
 This still requires a [Prometheus configuration](../dependencies/prometheus) to scrape Poller.
 
 :::note
-This is a [community provided](https://github.com/unifi-poller/unifi-poller/issues/309#issuecomment-796870916)
+This is a [community provided](https://github.com/unpoller/unpoller/issues/309#issuecomment-796870916)
 example.
 :::
 
@@ -122,7 +122,7 @@ volumes:
 
 Alternatively, if you choose to use a configuration file:
 
-- Copy the example [config file](https://github.com/unifi-poller/unifi-poller/blob/master/examples/up.conf.example)
+- Copy the example [config file](https://github.com/unpoller/unpoller/blob/master/examples/up.conf.example)
 - Edit it as necessary (in particular ensure that the `[unifi]`/`user` and `pass` variables are set)
 - In the `[influxdb]` section change ``url  = "http://127.0.0.1:8086"`` to become
   `url  = "http://THE_IP_OF_YOUR_DOCKER_HOST:8086"`

--- a/documentation/docs/install/dockercompose.md
+++ b/documentation/docs/install/dockercompose.md
@@ -39,11 +39,11 @@ file called `.env` in the same folder as the `docker-compose` yaml file
 Files beginning with a period `.` are generally hidden. You may need to use `ls -a` to find the `.env` file.
 :::
 
-- Copy the example [environment file](https://github.com/unifi-poller/unifi-poller/blob/master/init/docker/docker-compose.env.example)
+- Copy the example [environment file](https://github.com/unpoller/unpoller/blob/master/init/docker/docker-compose.env.example)
 - Edit it as necessary (in particular ensure that `UNIFI_USER` and `UNIFI_PASS` are set)
 - Save it as `.env` in the same folder as your `docker-compose.yml` (if you have one; if not see below)
 
-Download the [example](https://github.com/unifi-poller/unifi-poller/blob/master/init/docker/docker-compose.yml)
+Download the [example](https://github.com/unpoller/unpoller/blob/master/init/docker/docker-compose.yml)
 `docker-compose.yml` and add it to your existing one (if you have one; if not just make sure it is
 saved in the same folder as the `.env` file)
 
@@ -90,12 +90,12 @@ services:
       - GF_SECURITY_ADMIN_USER=admin
       - GF_SECURITY_ADMIN_PASSWORD=admin123
       - GF_INSTALL_PLUGINS=grafana-clock-panel,natel-discrete-panel,grafana-piechart-panel
-  unifi-poller:
-    image: golift/unifi-poller:latest
+  unpoller:
+    image: ghcr.io/unpoller/unpoller:latest
     restart: unless-stopped
     ports:
       - '9130:9130'
-    container_name: unifi-poller
+    container_name: unpoller
     environment:
       UP_INFLUXDB_DISABLE="true"
       UP_POLLER_DEBUG="false"
@@ -126,8 +126,8 @@ Alternatively, if you choose to use a configuration file:
 - Edit it as necessary (in particular ensure that the `[unifi]`/`user` and `pass` variables are set)
 - In the `[influxdb]` section change ``url  = "http://127.0.0.1:8086"`` to become
   `url  = "http://THE_IP_OF_YOUR_DOCKER_HOST:8086"`
-- Save it as `unifi-poller.conf` in the local location you use for Docker storage in a
-  folder called `unifi-poller`
+- Save it as `unpoller.conf` in the local location you use for Docker storage in a
+  folder called `unpoller`
 
 :::important
 When configuring make sure that you do **not** include `:8443` on the url of the controller
@@ -169,15 +169,15 @@ services:
       - GF_SECURITY_ADMIN_USER=admin
       - GF_INSTALL_PLUGINS=grafana-clock-panel,natel-discrete-panel,grafana-piechart-panel
 
-  unifi-poller:
+  unpoller:
     container_name: up-poller
     restart: unless-stopped
-    image: golift/unifi-poller:latest
+    image: ghcr.io/unpoller/unpoller:latest
     depends_on:
       - influxdb
       - grafana
     volumes:
-      - /YOURLOCALPATH/unifi-poller:/config
+      - /YOURLOCALPATH/unpoller:/config
 ```
 
 :::info

--- a/documentation/docs/install/dockercompose.md
+++ b/documentation/docs/install/dockercompose.md
@@ -8,7 +8,7 @@ The setup detailed below will install containers for Unpoller, Grafana and Influ
 
 ## First
 
-Make sure you have [set up a user](unifilogin) on your controller for Unpoller. 
+Make sure you have [set up a user](controllerlogin) on your controller for Unpoller. 
 
 ---
 

--- a/documentation/docs/install/freebsd.md
+++ b/documentation/docs/install/freebsd.md
@@ -20,7 +20,7 @@ If you don't have them, follow these instructions for installing
 Install compiled binary from ports run:
 
 ```shell
-pkg install net/unifi-poller
+pkg install net/unpoller
 ```
 
 ## Compile
@@ -28,14 +28,14 @@ pkg install net/unifi-poller
 To build and install from ports run:
 
 ```shell
-cd /usr/ports/net-mgmt/unifi-poller
+cd /usr/ports/net-mgmt/unpoller
 make install clean
 ```
 
 ## Maintenance
 
 See [Application Configuration](../install/configuration) and the
-[example config](https://github.com/unifi-poller/unifi-poller/blob/master/examples/up.conf.example)
+[example config](https://github.com/unpoller/unpoller/blob/master/examples/up.conf.example)
 file for additional post-install configuration information.
 
 :::important
@@ -47,25 +47,25 @@ Use these commands to maintain the service:
 
 ```shell
 # View manual.
-man unifi-poller
+man unpoller
 
 # Edit config file.
-# A defualt configuration file is placed in /usr/local/etc/unifi-poller/up.conf which is not overwritten on upgrades
-# A sample configuration is placed in /usr/local/etc/unifi-poller/up.conf.sample
-vi /usr/local/etc/unifi-poller/up.conf
+# A defualt configuration file is placed in /usr/local/etc/unpoller/up.conf which is not overwritten on upgrades
+# A sample configuration is placed in /usr/local/etc/unpoller/up.conf.sample
+vi /usr/local/etc/unpoller/up.conf
 
 # enable the service. Or edit /etc/rc.conf
 sysrc unifi_poller_enable="YES"
 
 # Start, Restart, Stop service.
-service unifi-poller start
-service unifi-poller restart
-service unifi-poller stop
+service unpoller start
+service unpoller restart
+service unpoller stop
 # Check service status, useful for scripts.
-service unifi-poller status
+service unpoller status
 
 # Logs should wind up in this file, but your syslog may differ.
-grep unifi-poller /var/log/messages
+grep unpoller /var/log/messages
 ```
 
 ## Next Steps

--- a/documentation/docs/install/grafana.md
+++ b/documentation/docs/install/grafana.md
@@ -18,11 +18,11 @@ The following explains the steps for InfluxDB; the Prometheus steps are very sim
 - Click `Add your first data source` on the home page you see after login.
 - Select the InfluxDB option
 - Set the following fields:
-        Name = UniFi InfluxDB (or whatever name you want) and set to default
-        URL = `http://influxdb1:8086`
-        Database = `unifi`
-        Username = `unifipoller`
-        Password = `unifipoller`
+- - Name = `UniFi InfluxDB` (or whatever name you want) and set to default
+- - URL = `http://influxdb1:8086` or `http://localhost:8086`
+- - Database = `unifi`
+- - Username = `unifipoller`
+- - Password = `unifipoller`
 - No other fields need to be changed or set on this page.
 - Click `Save & Test`
 - You should get green banner above the save and test that says 'Data Source is Working'
@@ -53,7 +53,7 @@ the changes, and apply them to your own custom dashboards.
       and copying graphs out of them.
     - This also allows you to identify problems with them and open an Issue.
 
-### Dashboards Instructions
+### Dashboard Installation Instructions
 
 - Simply click the + on the left nav bar in Grafana and click Import.
 - Put in the ID for the dashboard (below) and click the blue Load button.

--- a/documentation/docs/install/installmethod.md
+++ b/documentation/docs/install/installmethod.md
@@ -1,0 +1,50 @@
+---
+id: installmethod
+title: Install Method
+---
+
+## Chosing an Install Method
+
+There are two main methods to install the Unpollor 'suite' (Unpoller and accociated programs)
+
+### Docker Image
+This is the recommended way to install and the best option for new users.
+
+#### Advantages of Docker
+
+- Easy to configure, as you can rely on pre-existing work.
+- Easy to update.
+- Reliable and well-supported.
+
+#### Disadvantages of Docker
+
+- Some performance impact (though not likely to impact UniFi Poller, there is an overhead).
+- Relies on a base system for persistence of data.
+- May not be implemented on some useful platforms (eg NAS).
+
+### Manual Install
+Install each of the components individually
+
+#### Advantages of Manual
+
+- Works on systems that don't support Docker
+- You can make use of any components you already have
+- Less performance impact
+- Don't need hardware VM support
+
+#### Disadvantages of Manual
+
+- Harder to update
+- Requires manual configuration
+
+### Device Specific
+Some devices have specific install methods. If you have one of those devices the instructions for that device take precedence.
+
+- unRAID Template -- An unRAID Template is available in the Community Applications.
+- [Synology](Synology) -- Via Docker Image
+- [CloudKey](cloudkey) -- You may also install directly on a CloudKey, but that's an advanced setup and not generally recommended.
+
+## Next Steps
+[Installation Overview](overview)
+
+- [Setup controller login for Unpoller](controllerlogin)

--- a/documentation/docs/install/linux.md
+++ b/documentation/docs/install/linux.md
@@ -27,25 +27,25 @@ See below for how to install that repo!
 :::
 
 This works on any system with apt or yum. If your system does not use APT or YUM,
-then download a package from the [Releases](https://github.com/unifi-poller/unifi-poller/releases) page.
+then download a package from the [Releases](https://github.com/unpoller/unpoller/releases) page.
 Install the Go Lift package repo and UniFi Poller with this command:
 
 ```shell
-curl -s https://golift.io/repo.sh | sudo bash -s - unifi-poller
+curl -s https://golift.io/repo.sh | sudo bash -s - unpoller
 ```
 
 ## Maintenance
 
 See [Application Configuration](../install/configuration) and the
-[example config](https://github.com/unifi-poller/unifi-poller/blob/master/examples/up.conf.example)
+[example config](https://github.com/unpoller/unpoller/blob/master/examples/up.conf.example)
 file for additional post-install configuration information.
 
 - Edit the config file after installing the package, and correct the authentication
   information for your setup:
   ```shell
-  sudo nano /etc/unifi-poller/up.conf
+  sudo nano /etc/unpoller/up.conf
   # or
-  sudo vi /etc/unifi-poller/up.conf
+  sudo vi /etc/unpoller/up.conf
   ```
 
 :::important
@@ -55,11 +55,11 @@ controller if you are using `unifios`. Those are: UDM Pro, UDM, UXG, or CkoudKey
 
 - Restart the service:
   ```shell
-  sudo systemctl restart unifi-poller
+  sudo systemctl restart unpoller
   ```
 - Check the log:
   ```shell
-  tail -f -n100  /var/log/syslog /var/log/messages | grep unifi-poller
+  tail -f -n100  /var/log/syslog /var/log/messages | grep unpoller
   ```
 
 ## Next Steps

--- a/documentation/docs/install/macos.md
+++ b/documentation/docs/install/macos.md
@@ -23,7 +23,7 @@ If you don't have them, follow these instructions for installing
   ```
 1. Install Poller
   ```
-  brew install golift/mugs/unifi-poller
+  brew install golift/mugs/unpoller
   ```
 1. Edit the config file after installing the brew.
   :::important
@@ -32,20 +32,20 @@ If you don't have them, follow these instructions for installing
   :::
   See [Application Configuration](../install/configuration) for more information
   ```shell
-  nano /usr/local/etc/unifi-poller/up.conf
+  nano /usr/local/etc/unpoller/up.conf
   # or
-  vi /usr/local/etc/unifi-poller/up.conf
+  vi /usr/local/etc/unpoller/up.conf
   ```
 1. Start the service:
   ```shell
   # do not use sudo
-  brew services start unifi-poller
+  brew services start unpoller
   ```
-    - The log file should show up at `/usr/local/var/log/unifi-poller.log`
+    - The log file should show up at `/usr/local/var/log/unpoller.log`
     - If it does not show up, make sure your user has permissions to create the file.
 1. To restart (** required after upgrade**)
   ```shell
-  brew services restart unifi-poller
+  brew services restart unpoller
   ```
 
 ## Maintenance
@@ -56,13 +56,13 @@ All maintenance is done with homebrew. Example commands:
 # list all services brew controls.
 brew services list
 # restart poller.
-brew services restart unifi-poller
+brew services restart unpoller
 # running stop will make it not run on boot.
-brew services stop unifi-poller
+brew services stop unpoller
 # start makes it start now and on boot.
-brew services start unifi-poller
+brew services start unpoller
 # run starts it but will not re-start on boot.
-brew services run unifi-poller
+brew services run unpoller
 ```
 
 ## Next Steps

--- a/documentation/docs/install/overview.md
+++ b/documentation/docs/install/overview.md
@@ -1,0 +1,81 @@
+---
+id: overview
+title: Installation Overview
+---
+
+## Installation Overview
+If you prefer you can keep this page open as you walk though the installation steps of the Unpoller suite.
+
+The Unpoller suite allows you to collect data from your UniFi network controller, save it to a database, and then display it on pre-supplied attractive and data-rich Grafana dashboards
+
+The 'suite' consists of three main programs that work togather.
+UnPoller itself --> The Database --> Grafana viewer dashboards
+
+For more information check out [how it works](../poller/howitworks).
+If you're ready to get started, follow our step by step install guide below.
+
+### 1) Choose an Installation Method
+
+
+[Chosing an Install Method](../install/installmethod)
+
+### 2) Setup Unifi login for Unpoller
+No matter which method of installation you choose you will need to give Unpoller a way to access the infomation in your controller.
+You can setup Unpoller to get information from multiple controllers if you want, however we recommend getting one controller working before linking multiple.
+
+[Adding a login for Unpoller](unifilogin)
+
+### 3) Create Config
+The config tells Unpoller where to find the Unifi controller(s), database, and other infomation.
+(If you are doing a Manual installation you may need some information from Step-4 to complete the config.)
+
+[Creating/Modifying Config](configuration.md)
+
+### 4) Install Unpoller Suite
+Option 1 - Using a Docker image
+
+- [Installing via docker-compose](dockercompose)
+- [Installing via command line](docker)
+
+<details>
+  <summary>Option 2 - Manual installation</summary>
+
+**Install Database:**
+[InfluxDB](../dependencies/influxdb) and [Prometheus](../dependencies/prometheus) are both supported. You only need one.
+
+InfluxDB is recomended, as it supports both metrics and logging.
+Prometheus can hold only metrics. Loki is made by the Devs of Prometheus to hold logs. If you want both metrics & logging you will need to install Loki alongside Prometheus.
+
+**Install Grafana:**
+[Grafana Installation](../dependencies/grafana)
+
+**Install Unpoller:**
+Platform specific install docs:
+- [Windows](windows)
+- [MacOS](macos)
+- [Linux](linux)
+- [FreeBSD](freebsd)
+
+</details>
+
+### 5) Setup Grafana
+[Setup Grafana](grafana)
+
+### You're Done!
+If you're having issues:
+- Check for some [Common Problems](../help/common)
+- Check the [Unpoller FAQ](../poller/faq)
+- If you have questions regarding Docker check out the [Docker FAQ](../help/docker_faq)
+- Contact us on [Discord](https://golift.io/discord)
+- Or try [this](https://community.ui.com/questions/UniFi-Poller-Store-UniFi-Controller-Metrics-in-Prometheus-or-InfluxDB/58a0ea34-d2b3-41cd-93bb-d95d3896d1a1)
+thread on the UI community.
+- Alternatively, raise an [issue](https://github.com/unifi-poller/unifi-poller/issues) on Github.
+
+
+
+### Advanced Setup & Customization
+
+[Multiple Controllers](configuration.md#multiple-controllers)
+
+!!! Need to flush this out with links to Grafana guides to manipulating dashboards, presenting data, and any scraps of infomation we can find on the Unifi data that's being pulled.
+

--- a/documentation/docs/install/overview.md
+++ b/documentation/docs/install/overview.md
@@ -23,7 +23,7 @@ If you're ready to get started, follow our step by step install guide below.
 No matter which method of installation you choose you will need to give Unpoller a way to access the infomation in your controller.
 You can setup Unpoller to get information from multiple controllers if you want, however we recommend getting one controller working before linking multiple.
 
-[Adding a login for Unpoller](unifilogin)
+[Adding a login for Unpoller](controllerlogin)
 
 ### 3) Create Config
 The config tells Unpoller where to find the Unifi controller(s), database, and other infomation.

--- a/documentation/docs/install/overview.md
+++ b/documentation/docs/install/overview.md
@@ -69,7 +69,7 @@ If you're having issues:
 - Contact us on [Discord](https://golift.io/discord)
 - Or try [this](https://community.ui.com/questions/UniFi-Poller-Store-UniFi-Controller-Metrics-in-Prometheus-or-InfluxDB/58a0ea34-d2b3-41cd-93bb-d95d3896d1a1)
 thread on the UI community.
-- Alternatively, raise an [issue](https://github.com/unifi-poller/unifi-poller/issues) on Github.
+- Alternatively, raise an [issue](https://github.com/unpoller/unpoller/issues) on Github.
 
 
 

--- a/documentation/docs/install/synology.md
+++ b/documentation/docs/install/synology.md
@@ -62,12 +62,12 @@ helps avoid conflicts with the host or other containers you might have that we c
 
 1. Select `Registry`
 1. Use the search box to find the following:
-    - unifi-poller for `golift/unifi-poller:latest` https://hub.docker.com/r/golift/unifi-poller/
+    - unpoller for `ghcr.io/unpoller/upoller:latest` https://github.com/unpoller/unpoller/pkgs/container/unpoller
     - grafana for `grafana/grafana:latest` https://hub.docker.com/r/grafana/grafana/
     - influxdb for `influxdb:1.8` https://hub.docker.com/_/influxdb/
 
 :::note
-The unifi-poller container requires the InfluxDB database to already exist, so you *must* create the containers in the order below.
+The unpoller container requires the InfluxDB database to already exist, so you *must* create the containers in the order below.
 :::
 
 ### Create influxdb container
@@ -93,16 +93,16 @@ The unifi-poller container requires the InfluxDB database to already exist, so y
     - Click `APPLY`
     - Click `NEXT`
     - Click `APPLY`
-1. We now need to create the database that the unifi-poller container will use.
+1. We now need to create the database that the unpoller container will use.
     - SSH into your Synology
     - Run the command `sudo docker exec -it influxdb1 bash`
     - Follow the [InfluxDB Post Setup instructions](../dependencies/influxdb#post-setup).
 
-## Create unifi-poller container
+## Create unpoller container
 
-1. In `Image` select `golift/unifi-poller:latest` and click launch
-1. Leave general settings alone - container name should be `golift-unifi-poller1`,
-    unless you created other unifi-pollers
+1. In `Image` select `ghcr.io/unpoller/unpoller:latest` and click launch
+1. Leave general settings alone - container name should be `unpoller1`,
+    unless you created other unpollers
 1. Click Advanced Settings
 1. On the network tab:
     - Add your network - in this example: `Grafana_Net`
@@ -127,7 +127,7 @@ if you are using `unifios`. Those are: UDM Pro, UDM, UXG, or CkoudKey with recen
 ## Check that poller and influx are working
 
 1. Select the `Container` tab in the Docker UI
-1. Double click `golift-unifi-poller1`
+1. Double click `unpoller1`
 1. Select the `Log` tab
 1. After a couple of minutes you should see an entry like the following,
   if you do then everything is working ok:

--- a/documentation/docs/install/windows.md
+++ b/documentation/docs/install/windows.md
@@ -19,12 +19,12 @@ You can review the [installation overview](overview.md) if needed.
 ## Install
 
 As it is now, a pre-compiled windows binary (.exe) is provided on the
-[Releases](https://github.com/unifi-poller/unifi-poller/releases) page `unifi-poller.amd64.exe.zip`.
+[Releases](https://github.com/unpoller/unpoller/releases) page `unpoller.amd64.exe.zip`.
 Unzip the file where you would like to install Unpoller.
 Drop a valid [config file](configuration) `up.conf` in the same directory, and you can run this on Windows by using the following command:
 
 ```shell
-unifi-poller.amd64.exe -c up.conf
+unpoller.amd64.exe -c up.conf
 ```
 As long as Unpoller is running it should be retreiving updated data from your controller.
 

--- a/documentation/docs/install/windows.md
+++ b/documentation/docs/install/windows.md
@@ -12,27 +12,25 @@ a working (and supported) version of [Grafana](../dependencies/grafana) and at
 least one of [InfluxDB](../dependencies/influxDB) or [Prometheus](../dependencies/prometheus).
 If you don't have them, follow these instructions for installing
 [InfluxDB](../dependencies/influxdb) and [Grafana](../dependencies/grafana).
+You can review the [installation overview](overview.md) if needed.
 
 ---
 
 ## Install
 
 As it is now, a pre-compiled windows binary (.exe) is provided on the
-[Releases](https://github.com/unifi-poller/unifi-poller/releases) page.
-Combine this with a valid config file and you can run this on Windows.
-Please contact us on [Discord](https://golift.io/discord) if you need any help.
+[Releases](https://github.com/unifi-poller/unifi-poller/releases) page `unifi-poller.amd64.exe.zip`.
+Unzip the file where you would like to install Unpoller.
+Drop a valid [config file](configuration) `up.conf` in the same directory, and you can run this on Windows by using the following command:
 
 ```shell
-unifi-poller.exe -c up.conf
+unifi-poller.amd64.exe -c up.conf
 ```
+As long as Unpoller is running it should be retreiving updated data from your controller.
 
-:::important
-When configuring make sure that you do **not** include `:8443` on the url of the controller
-if you are using `unifios`. Those are: UDM Pro, UDM, UXG, or CkoudKey with recent firmware.
-:::
+Please contact us on [Discord](https://golift.io/discord) if you need any help.
 
 ## Next Steps
+[Installation Overview](overview)
 
-1. [Configure the Application](../install/configuration).
-1. Don't forget the [Grafana Plugins](../dependencies/grafana#plugins).
-1. Finish [Setting-up Grafana](../install/grafana).
+- [Setup Grafana](grafana)

--- a/documentation/docs/poller/changelog.md
+++ b/documentation/docs/poller/changelog.md
@@ -16,7 +16,7 @@ title: Change Log
 ### `v2.0.1` (06.15.2020) Enhancements
 
 This release contains enhancements.
-See [this pull request](https://github.com/unifi-poller/unifi-poller/pull/240) for more details.
+See [this pull request](https://github.com/unpoller/unpoller/pull/240) for more details.
 
 -   Set timezone with TZ environment variable.
 -   Fixes ARM64 Docker builds.
@@ -32,7 +32,7 @@ See [this pull request](https://github.com/unifi-poller/unifi-poller/pull/240) f
 
 ### `v2.0` (02.06.2020) Multi-Controller Support, FreeBSD pkg + APT & YUM repos + DPI
 
-[v2.0](https://github.com/unifi-poller/unifi-poller/releases/tag/v2.0.0)
+[v2.0](https://github.com/unpoller/unpoller/releases/tag/v2.0.0)
 
 #### v2 Breaking Changes
 
@@ -47,20 +47,20 @@ file format. If you use environment variables, they all need to be updated!
 
 #### v2 Updates
 
--   New [GitHub Org](https://github.com/unifi-poller) created for UniFi Poller. Moved from personal repo.
--   [InfluxDB output code moved to separate library](https://github.com/unifi-poller/influxunifi)
+-   New [GitHub Org](https://github.com/unpoller) created for UniFi Poller. Moved from personal repo.
+-   [InfluxDB output code moved to separate library](https://github.com/unpoller/pkg/influxunifi)
     as modular plugin. (output module)
--   [UniFi input code moved to separate library](https://github.com/unifi-poller/inputunifi)
+-   [UniFi input code moved to separate library](https://github.com/unpoller/pkg/inputunifi)
     as modular plugin. (input module)
--   [Prometheus code moved to separate library](https://github.com/unifi-poller/promunifi)
+-   [Prometheus code moved to separate library](https://github.com/unpoller/pkg/promunifi)
     as modular plugin. (output module)
--   [Poller app code moved to separate library](https://github.com/unifi-poller/poller).
+-   [Poller app code moved to separate library](https://github.com/unpoller/pkg/poller).
     The main repo only handles builds and golang vendors now.
--   [UniFi API code moved to new location](https://github.com/unifi-poller/unifi)
-    from golift github org. It fits better in the new unifi-poller org.
+-   [UniFi API code moved to new location](https://github.com/unpoller/unifi)
+    from golift github org. It fits better in the new unpoller org.
 -   [New library created](https://golift.io/cnfg) for config file and environment variable parsing.
 -   Dynamic go plugin support added for output modules. May not prove useful.
--   [Example (MySQL) dynamic output module](https://github.com/unifi-poller/mysqlunifi)
+-   [Example (MySQL) dynamic output module](https://github.com/unpoller/pkg/mysqlunifi)
     created (for above).
 -   Support for latest UDM OS using 5.12.55+ controller version. API paths changed.
 -   Switch from `dep` to go modules. Now using to Go 1.13, from 1.12.
@@ -78,14 +78,14 @@ file format. If you use environment variables, they all need to be updated!
     Multi-controller support added**, but hidden (since most users wont need it).
 -   Many build fixes and improvements for packages, FreeBSD, Homebrew and Docker.
 -   Type Conflict error fixes for InfluxDB (and probably more errors added, uhg).
--   [Install script](https://github.com/unifi-poller/unifi-poller/blob/master/scripts/install.sh)
+-   [Install script](https://github.com/unpoller/unpoller/blob/master/scripts/install.sh)
     updates. Supports arm64 better and now supports FreeBSD packages.
 -   unRAID [Community Applications template](https://github.com/selfhosters/unRAID-CA-templates/blob/master/templates/unifi-poller.xml)
     updated.
--   Many many [wiki updates](https://github.com/unifi-poller/unifi-poller/wiki).
--   The wiki was moved into its [own repo](https://github.com/unifi-poller/wiki) and
+-   Many many [wiki updates](https://unpoller.com/).
+-   The wiki was moved into its [own repo](https://github.com/unpoller/unpoller.github.io) and
     attached to a build pipeline that auto deploys tested changes to the main wiki (linked above)
--   The dashboards were moved into their [own repo](https://github.com/unifi-poller/dashboards)
+-   The dashboards were moved into their [own repo](https://github.com/unpoller/dashboards)
     and attached to a build pipeline that auto deploys them to Grafana.com.
 
 ## Older (pre-2020) Releases
@@ -95,16 +95,16 @@ They are condensed and contain fewer details than the more recent releases above
 
 ### `v1.6.3` (12.12.2019) Exit Behavior Changed
 
-[v1.6.1](https://github.com/unifi-poller/unifi-poller/releases/tag/v1.6.1),
-[v1.6.2](https://github.com/unifi-poller/unifi-poller/releases/tag/v1.6.2),
-[v1.6.3](https://github.com/unifi-poller/unifi-poller/releases/tag/v1.6.3)
+[v1.6.1](https://github.com/unpoller/unpoller/releases/tag/v1.6.1),
+[v1.6.2](https://github.com/unpoller/unpoller/releases/tag/v1.6.2),
+[v1.6.3](https://github.com/unpoller/unpoller/releases/tag/v1.6.3)
 
 -   Prometheus bug fixes.
 -   App no longer exits on error (yay unRAID users).
 
 ### `v1.6` (12.01.2019) Prometheus Support & InfluxDB Improvements + Dashboard Updates
 
-[v1.6](https://github.com/unifi-poller/unifi-poller/releases/tag/v1.6.0)
+[v1.6](https://github.com/unpoller/unpoller/releases/tag/v1.6.0)
 
 -   **Prometheus support added.**
 -   Five new Prometheus dashboards.
@@ -114,7 +114,7 @@ They are condensed and contain fewer details than the more recent releases above
 
 ### `v1.5.4` (10.08.2019) Bug Fixes
 
-[v1.5.4](https://github.com/unifi-poller/unifi-poller/releases/tag/v1.5.4)
+[v1.5.4](https://github.com/unpoller/unpoller/releases/tag/v1.5.4)
 
 -   This release provides fixes for a handful of bugs that only affect a few controllers and use cases.
 -   `max_errors` was removed from the config file. Any error will cause the poller to exit now.
@@ -122,9 +122,9 @@ They are condensed and contain fewer details than the more recent releases above
 
 ### `v1.5.3` (09.09.2019) UDM and UDM Pro - Docker ENV Support
 
-[v1.5.1](https://github.com/unifi-poller/unifi-poller/releases/tag/v1.5.1),
-[v1.5.2](https://github.com/unifi-poller/unifi-poller/releases/tag/v1.5.2),
-[v1.5.3](https://github.com/unifi-poller/unifi-poller/releases/tag/v1.5.3)
+[v1.5.1](https://github.com/unpoller/unpoller/releases/tag/v1.5.1),
+[v1.5.2](https://github.com/unpoller/unpoller/releases/tag/v1.5.2),
+[v1.5.3](https://github.com/unpoller/unpoller/releases/tag/v1.5.3)
 
 -   UDM and UDM Pro (UniFi Dream Machine) support added. 5.11.38
 -   Dashboards Updated
@@ -138,9 +138,9 @@ They are condensed and contain fewer details than the more recent releases above
 
 ### `v1.5` (07.11.2019) Intrusion Detection Data
 
-[v1.4.1](https://github.com/unifi-poller/unifi-poller/releases/tag/v1.4.1),
-[v1.4.2](https://github.com/unifi-poller/unifi-poller/releases/tag/v1.4.2),
-[v1.5](https://github.com/unifi-poller/unifi-poller/releases/tag/v1.5.0)
+[v1.4.1](https://github.com/unpoller/unpoller/releases/tag/v1.4.1),
+[v1.4.2](https://github.com/unpoller/unpoller/releases/tag/v1.4.2),
+[v1.5](https://github.com/unpoller/unpoller/releases/tag/v1.5.0)
 
 -   UniFi 5.11.x support.
 -   Multi-architecture Docker Images
@@ -152,7 +152,7 @@ They are condensed and contain fewer details than the more recent releases above
 
 ### `v1.4` (07.05.2019) Data Surplus
 
-[v1.4](https://github.com/unifi-poller/unifi-poller/releases/tag/v1.4.0)
+[v1.4](https://github.com/unpoller/unpoller/releases/tag/v1.4.0)
 
 -   Clients and UAP dashboards overhauled.
 -   Data formats changed.
@@ -174,9 +174,9 @@ They are condensed and contain fewer details than the more recent releases above
 
 ### `v1.3.3` (06.19.2019) Exit on Error
 
-[v1.3.1](https://github.com/unifi-poller/unifi-poller/releases/tag/v1.3.1),
-[v1.3.2](https://github.com/unifi-poller/unifi-poller/releases/tag/v1.3.2),
-[v1.3.3](https://github.com/unifi-poller/unifi-poller/releases/tag/v1.3.3)
+[v1.3.1](https://github.com/unpoller/unpoller/releases/tag/v1.3.1),
+[v1.3.2](https://github.com/unpoller/unpoller/releases/tag/v1.3.2),
+[v1.3.3](https://github.com/unpoller/unpoller/releases/tag/v1.3.3)
 
 -   General code updates.
 -   Bug fixes.
@@ -191,9 +191,9 @@ They are condensed and contain fewer details than the more recent releases above
 
 ### `v1.3` (06.13.2019) Better Debug, Better Output, Better Build, Better Layout
 
-[v1.2.3](https://github.com/unifi-poller/unifi-poller/releases/tag/v1.2.3),
-[v1.2.2](https://github.com/unifi-poller/unifi-poller/releases/tag/v1.2.2),
-[v1.3](https://github.com/unifi-poller/unifi-poller/releases/tag/v1.3.0)
+[v1.2.3](https://github.com/unpoller/unpoller/releases/tag/v1.2.3),
+[v1.2.2](https://github.com/unpoller/unpoller/releases/tag/v1.2.2),
+[v1.3](https://github.com/unpoller/unpoller/releases/tag/v1.3.0)
 
 -   Improved logging and debug.
 -   Build pipeline updates.
@@ -205,7 +205,7 @@ They are condensed and contain fewer details than the more recent releases above
 
 ### `v1.2` (06.05.2019) Better Site support
 
-[v1.2](https://github.com/unifi-poller/unifi-poller/releases/tag/v1.2.0)
+[v1.2](https://github.com/unpoller/unpoller/releases/tag/v1.2.0)
 
 -   Bug fixes.
 -   Site name added to metrics making dashboards better.
@@ -213,8 +213,8 @@ They are condensed and contain fewer details than the more recent releases above
 
 ### `v1.1.1` (05.30.2019) Packages! Better run support
 
-[v1.1.0](https://github.com/unifi-poller/unifi-poller/releases/tag/v1.1.0),
-[v1.1.1](https://github.com/unifi-poller/unifi-poller/releases/tag/v1.1.1)
+[v1.1.0](https://github.com/unpoller/unpoller/releases/tag/v1.1.0),
+[v1.1.1](https://github.com/unpoller/unpoller/releases/tag/v1.1.1)
 
 -   Adds multi site support. Was only working with `default`.
 -   Provides precompiled binaries for linux amd64 and macos amd64.
@@ -223,10 +223,10 @@ They are condensed and contain fewer details than the more recent releases above
 
 ### `v1.0` (01.26.2019) Cleanup and New Libraries
 
-[v0.2a](https://github.com/unifi-poller/unifi-poller/releases/tag/v0.2a),
-[v0.2b](https://github.com/unifi-poller/unifi-poller/releases/tag/V0.2b),
-[v0.3](https://github.com/unifi-poller/unifi-poller/releases/tag/0.3.0),
-[v1.0](https://github.com/unifi-poller/unifi-poller/releases/tag/v1.0.0)
+[v0.2a](https://github.com/unpoller/unpoller/releases/tag/v0.2a),
+[v0.2b](https://github.com/unpoller/unpoller/releases/tag/V0.2b),
+[v0.3](https://github.com/unpoller/unpoller/releases/tag/0.3.0),
+[v1.0](https://github.com/unpoller/unpoller/releases/tag/v1.0.0)
 
 -   **Adds more device support: UAP USG**
 -   Adds better json parsing.
@@ -236,6 +236,6 @@ They are condensed and contain fewer details than the more recent releases above
 
 ### `v0.2` (04.22.2018) Full Client Support
 
-[v0.2](https://github.com/unifi-poller/unifi-poller/releases/tag/v0.2)
+[v0.2](https://github.com/unpoller/unpoller/releases/tag/v0.2)
 
 -   Adds Support for Pulling Client Data

--- a/documentation/docusaurus.config.js
+++ b/documentation/docusaurus.config.js
@@ -40,7 +40,7 @@ module.exports = {
             },
             {
               label: 'Send Feedback',
-              href: 'https://golift.io/unifi-poller/issues/new',
+              href: 'https://golift.io/unpoller/issues/new',
             },
           ],
         },
@@ -85,7 +85,7 @@ module.exports = {
         },
       ],
       copyright: `<div class="row"><div class="col footer__col">
-      <a href="https://hub.docker.com/r/golift/unifi-poller">&#9733; THIS PROJECT ON DOCKERHUB</a>
+      <a href="https://github.com/unpoller/unpoller/pkgs/container/unpoller">&#9733; THIS PROJECT ON GHCR.IO</a>
       </div><div class="col footer__col" style="text-align:left;">
       Copyright © 2018-${new Date().getFullYear()} Go Lift
       </div><div class="col footer__col"><a href="https://golift.io"><img src="https://docs.golift.io/integrations/golift.png" /></a></div></div>`,

--- a/documentation/sidebars.js
+++ b/documentation/sidebars.js
@@ -11,7 +11,7 @@ module.exports = {
     ],
     "Installation": [
       'install/gettingstarted',
-      'install/installationmethod',
+      'install/installmethod',
       'install/controllerlogin',
       'install/dockercompose',
       'install/docker',

--- a/documentation/sidebars.js
+++ b/documentation/sidebars.js
@@ -11,8 +11,10 @@ module.exports = {
     ],
     "Installation": [
       'install/gettingstarted',
-      'install/docker',
+      'install/installationmethod',
+      'install/controllerlogin',
       'install/dockercompose',
+      'install/docker',
       'install/freebsd',
       'install/macos',
       'install/linux',


### PR DESCRIPTION
Picks up #3 

from @KzBoy

> Cleaned up a lot of missing or confusing documentation regarding the install process.
> 
> Added instructions for Windows that was missing in quite a few locations,
> 
> Also overhauled the installation process itself.
> Added a 'Installation Overview' page to help users know the steps to creating a working installation for their particular setup. This would replace the 'Getting Started' page.
> Broke out the Installation methods into it's own page to make it easy to see what the options are and make adding any additional options easier in the future.
> 
> New install flow broken down into 5 steps (See the 'Overview' page)
> 
> This gives the user a 'map' for the install process and a place to refer to if they get lost/confused about what to do next or simply need help.

Also fixed many `unifi-poller` to `unpoller` conversions