### PR TITLE
fix influx version

### DIFF
--- a/documentation/docs/install/dockercompose.md
+++ b/documentation/docs/install/dockercompose.md
@@ -172,7 +172,7 @@ version: '3'
 services:
   influxdb:
     restart: always
-    image: influxdb:2.5
+    image: influxdb:1.8
     ports:
       - '8086:8086'
     volumes:


### PR DESCRIPTION
- Closes https://github.com/unpoller/unpoller/issues/466

### Context
The app supports Influx 2, but the dashboards do not, so it's not recommended. Advanced users that wish to build their own dashboards are encouraged to use 2.x.