### PR TITLE
Document remote API key, UnifiOS terminology, and scrape interval limits

### DIFF
--- a/documentation/docs/dependencies/prometheus.md
+++ b/documentation/docs/dependencies/prometheus.md
@@ -155,3 +155,19 @@ scrape_configs:
 ```
 
 The standard ``/metrics`` path that the above snippet uses returns metrics for all configured controllers.
+
+## Remote API Key, Multiple Sites
+
+If you're using the [Remote API key](../install/configuration#remote-api-key) method,
+UniFi Poller discovers all of your sites automatically and exposes metrics for all of them
+on the standard ``/metrics`` path, the same as the Final Approach above:
+
+```yaml
+scrape_configs:
+  - job_name: 'unpoller'
+    scrape_interval: 30s
+    static_configs:
+      - targets: ['unpoller-host:9130']
+```
+
+Replace `unpoller-host` with the IP or hostname of the machine running UniFi Poller.

--- a/documentation/docs/install/configuration.md
+++ b/documentation/docs/install/configuration.md
@@ -71,10 +71,13 @@ The unifi section begins with the `[unifi]` header and has the following paramet
 |---|---|---|
 |UP_UNIFI_DISABLE |disable |`false`  turns off this input. don't do that! |
 |UP_UNIFI_DYNAMIC |dynamic |`false`  enables dynamic lookups (from prometheus) |
+|UP_UNIFI_REMOTE |remote |`false` use the Ubiquiti Remote (Site Manager) API instead of connecting to a local controller. Requires `remote_api_key`, and cannot be combined with `[[unifi.controller]]` entries. |
+|UP_UNIFI_REMOTE_API_KEY |remote_api_key |`""` API key generated from your Ubiquiti (UI) account. Only used when `remote = true`. |
 |UP_UNIFI_DEFAULT_ROLE |unifi.defaults.role |`URL` allows grouping controllers |
 |UP_UNIFI_DEFAULT_URL|unifi.defaults.url|`"https://127.0.0.1:8443"` only applies if no controllers are defined (next section) |
-|UP_UNIFI_DEFAULT_USER |unifi.defaults.user |`"unifipoller"` default applies to any controller without a username |
-|UP_UNIFI_DEFAULT_PASS |unifi.defaults.pass |`""` default applies to any controller without a password |
+|UP_UNIFI_DEFAULT_USER |unifi.defaults.user |`"unifipoller"` default applies to any controller without a username. Not used with `api_key` or when `remote = true`. |
+|UP_UNIFI_DEFAULT_PASS |unifi.defaults.pass |`""` default applies to any controller without a password. Not used with `api_key` or when `remote = true`. |
+|UP_UNIFI_DEFAULT_API_KEY |unifi.defaults.api_key |`""` local API key for the controller, used instead of `user`/`pass`. See [Unifi Controller Login](../install/controllerlogin). |
 |UP_UNIFI_DEFAULT_SAVE_SITES |unifi.defaults.save_sites |`true`  |
 |UP_UNIFI_DEFAULT_SAVE_IDS |unifi.defaults.save_ids |`false` Only works with InfluxDB / Loki|
 |UP_UNIFI_DEFAULT_SAVE_EVENTS |unifi.defaults.save_events |`false` Only works with InfluxDB / Loki, added in v2.0.2|
@@ -88,7 +91,10 @@ The unifi section begins with the `[unifi]` header and has the following paramet
 
 :::important
 When configuring make sure that you do **not** include `:8443` on the url of the controller
-if you are using `unifios`. Those are: UDM Pro, UDM, UXG, or CloudKey with recent firmware.
+if you are using UnifiOS. UnifiOS devices (UDM Pro, UDM, UXG, UCK with recent firmware, and
+self-hosted UnifiOS Network Server) proxy the controller on port `443`, so the URL just
+works without a port, eg `https://192.168.1.1`. Non-UnifiOS controllers (Cloud Key Gen1,
+software controllers) still use port `8443`, eg `https://192.168.1.1:8443`.
 :::
 
 Most `unifi` configuration will look like this:
@@ -104,6 +110,27 @@ Most `unifi` configuration will look like this:
   save_alarms = false
   save_dpi = false
   sites = [ "default" ]
+```
+
+### Remote API Key
+
+If your UniFi Poller instance cannot reach your controller directly (for example, it runs
+on a different network), you can use Ubiquiti's Remote (Site Manager) API instead. Generate
+an API key from your Ubiquiti account, then set `remote = true` and `remote_api_key` at the
+`[unifi]` level (not inside `[unifi.defaults]` or `[[unifi.controller]]`). No `url`, `user`,
+or `pass` is needed; UniFi Poller discovers your consoles/sites automatically. This works
+with multiple sites on the same account.
+
+```toml
+[unifi]
+  dynamic = false
+  remote = true
+  remote_api_key = "my-secret"
+
+[unifi.defaults]
+  save_sites = true
+  save_dpi = true
+  verify_ssl = false
 ```
 
 Same example, but for Docker:
@@ -170,6 +197,14 @@ If you don't use Prometheus, set `disable` to `true`.
 
 :::tip
 The [Prometheus](../dependencies/prometheus) page has a full explanation of how to configure Poller.
+:::
+
+:::note Namespace vs. User
+`UP_PROMETHEUS_NAMESPACE` (default `unifipoller`) is only a metric name prefix; it has
+nothing to do with `UP_UNIFI_DEFAULT_USER`/`UP_UNIFI_CONTROLLER_0_USER`, which is the
+username of the read-only account you created on the controller. It's easy to confuse
+the two, especially if you named your controller account something other than
+`unifipoller` and left the namespace at its default.
 :::
 
 ### InfluxDB

--- a/documentation/docs/install/controllerlogin.md
+++ b/documentation/docs/install/controllerlogin.md
@@ -5,6 +5,23 @@ title: Unifi Controller Login
 
 ## Configuring the Unifi controller
 
+UniFi Poller supports three ways to authenticate to your UniFi environment. Pick the one
+that matches your setup:
+
+1. **Local controller account** - a username/password for a Limited Admin user on the
+   controller. Works with every controller type. This is the method documented below and
+   used throughout the rest of these docs.
+1. **Local API key** - an API key generated directly on newer UnifiOS controllers (Network
+   Server version dependent), used in place of a username/password. Set `api_key` instead
+   of `user`/`pass` on the controller. This avoids storing a password, but is only
+   available on controllers new enough to support API key generation in their UI.
+1. **Remote API key** - an API key generated from your Ubiquiti (UI) account, used when
+   UniFi Poller cannot reach the controller directly (for example, it runs on a different
+   network than the controller). See [Application Configuration](configuration#remote-api-key)
+   for how to configure this method.
+
+The rest of this page covers the local controller account method.
+
 The only requirement of the controller is that UniFi Poller can log in to it and extract data.
 For this purpose go ahead and create a new user. Make a note of the username and password you have chosen.
 
@@ -12,7 +29,10 @@ Adding a user depends on the type of controller you have.
 
 ### UnifiOS Controller
 
-If your controller is on a UDM, UXG, or UDM-Pro or UCK running UnifiOS then it is recommended that a
+UnifiOS is Ubiquiti's underlying OS/Network Server, not a specific device model - it runs on
+UDM, UDM Pro, UDM SE, UDM Pro Max, UXG, UXG Pro, UXG Lite, UCG (Cloud Gateway) Ultra/Max/Fiber,
+UCK G2/G2 Plus, and self-hosted UnifiOS Network Server installs. If your controller runs
+UnifiOS (check under Settings > System in the UniFi Network app), it is recommended that a
 Limited Admin user is created with Read-Only rights to the UniFi Network app. Other access
 levels may not work correctly.
 
@@ -23,7 +43,8 @@ This is the default, will be used throughout these docs.
 
 ### Non UnifiOS Controller
 
-If you are using another controller type (eg. Cloudkey or Virtual) then create a menual read-only user.
+If you are using another controller type (eg. Cloudkey Gen1 or a software controller not
+running UnifiOS) then create a manual read-only user.
 
 The `Email` field will be the 'username' you will need to create the config file.
 

--- a/documentation/docs/install/gettingstarted.md
+++ b/documentation/docs/install/gettingstarted.md
@@ -26,18 +26,29 @@ configuration steps. The first of these is to set up the controller correctly.
 ## Configuring the controller
 
 The only requirement of the controller is that UniFi Poller can log in to it and extract data.
-For this purpose go ahead and create a new user now. Make a note of the username and password you have chosen.
+UniFi Poller supports three login methods: a local controller account, a local controller
+API key, or a Remote (Site Manager) API key. See
+[Unifi Controller Login](../install/controllerlogin) for a full comparison and setup
+instructions for each.
 
-If your controller is on a UDM, UXG, or UDM-Pro or UCK running UnifiOS then it is recommended that a
-Limited Admin user is created with Read-Only rights to the UniFi Network app. Other access
-levels may not work correctly.
+For most users, go ahead and create a new local controller user now. Make a note of the
+username and password you have chosen.
+
+If your controller runs UnifiOS (UDM, UDM Pro, UXG, UCG, UCK G2, or self-hosted UnifiOS
+Network Server) then it is recommended that a Limited Admin user is created with Read-Only
+rights to the UniFi Network app. Other access levels may not work correctly.
 
 For example,the screenshot below show the username chosen as `unifipoller`.
 This is the default, will be used throughout these docs.
 
 ![img](../../static/img/UDM_user.png)
 
-If you are using another controller type (eg. Cloudkey or Virtual) then create a read-only user.
+If you are using another controller type (eg. Cloudkey Gen1 or a software controller not
+running UnifiOS) then create a read-only user.
+
+If UniFi Poller runs on a different network than your controller (for example, in the
+cloud, or a remote site), use the Remote API key method instead - see
+[Application Configuration](../install/configuration#remote-api-key).
 
 ## Next Steps
 

--- a/documentation/docs/poller/faq.md
+++ b/documentation/docs/poller/faq.md
@@ -36,3 +36,17 @@ available to display the data.
 - Because UniFi Poller just picks up data from the controller using the API,
   the only way of getting an accurate answer about what is shown is by asking UI themselves.
   Given that they don't officially support the API there may be little chance of an answer
+
+**My Prometheus graphs show dips or drop to zero, even though I set a short scrape interval**
+
+- The UniFi controller's own API does not update every value on every request; some data
+  points only refresh roughly once a minute (or slower), regardless of how often UniFi
+  Poller is scraped or how often Prometheus scrapes UniFi Poller. Setting a Prometheus
+  `scrape_interval` shorter than the controller's own update rate will not increase the
+  resolution of the underlying data.
+- This matters most for rate-based panels. Prometheus's `rate()` function needs at least
+  two real data points inside the range vector you give it; if the range is shorter than
+  the controller's update interval, `rate()` can return `0` even though traffic didn't
+  actually stop. As a rule of thumb, use a range of at least `3m` (eg. `rate(metric[3m])`)
+  for byte/packet rate metrics, and don't set your Prometheus `scrape_interval` for the
+  UniFi Poller job below `30s`.


### PR DESCRIPTION
## Summary
- Documents the Remote (Site Manager) API key login method, including a configuration example and a Prometheus multi-site scrape example (#55)
- Documents the local controller API key option as an alternative to user/pass (#55)
- Replaces the UDM/UXG/UDM-Pro/UCK device list with UnifiOS-based language, since UnifiOS now runs on more devices and can be self-hosted (#55)
- Clarifies that UnifiOS controllers work on port 443 (no `:8443` needed) vs. non-UnifiOS controllers, which still need `:8443` (#42)
- Adds a note distinguishing the Prometheus `namespace` setting from the controller `user` setting, since these are unrelated and easy to conflate (#42)
- Adds an FAQ entry explaining that the UniFi controller API doesn't update every value on every request, so lowering the Prometheus scrape interval doesn't increase resolution, and recommends a `rate()` range of at least `3m` to avoid spurious zeros (closes the outstanding question on #24)

## Test plan
- [x] `yarn build` in `documentation/` completes with no broken-link warnings
- [ ] Spot-check rendered pages (`gettingstarted`, `controllerlogin`, `configuration`, `prometheus`, `faq`) via `yarn start`