### PR TITLE
Replace Renovate with Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/documentation"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,0 @@
-{
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:recommended"
-  ]
-}


### PR DESCRIPTION
## Summary
- Removes `.github/renovate.json` and adds `.github/dependabot.yml`
- Dependabot is configured with weekly checks for:
  - npm dependencies in `documentation/` (yarn.lock/package.json)
  - GitHub Actions pinning in `.github/workflows/`

## Notes
Checked current dependency/action versions as a "round of updates" — everything (Docusaurus, React, and all pinned Actions) is already at the latest release, so no version bumps were needed this round. Future updates will come from Dependabot going forward.

## Test plan
- [x] `yarn install` in `documentation/` completes with no lockfile changes
- [x] Verified GitHub Actions SHAs match their latest release tags
- [ ] Confirm Dependabot PRs start appearing on schedule

🤖 Generated with [Claude Code](https://claude.com/claude-code)